### PR TITLE
ci(driver-service): enhance workflow with release and dev strategies

### DIFF
--- a/.github/workflows/driver-service-ci.yml
+++ b/.github/workflows/driver-service-ci.yml
@@ -1,17 +1,26 @@
 name: Driver Service CI
 
 on:
-  push:
-    paths:
-      - 'driver-service/**'
-      - '.github/workflows/driver-service-ci.yml'
   pull_request:
+    branches:
+      - 'driver-service'
+      - 'main'
     paths:
       - 'driver-service/**'
       - '.github/workflows/driver-service-ci.yml'
 
+  push:
+    branches:
+      - 'driver-service'
+      - 'main'
+    paths:
+      - 'driver-service/**'
+      - '.github/workflows/driver-service-ci.yml'
+    tags:
+      - 'driver-service/v*'
+
 env:
-  SHOULD_PUSH_IMAGE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+  SHOULD_PUSH_IMAGE: ${{ github.event_name == 'push' }}
 
 permissions:
   contents: read
@@ -70,7 +79,9 @@ jobs:
           ghcr.io/${{ github.repository_owner }}/driver-service
         tags: | 
           type=sha
-          type=raw,value=latest,enable=${{ env.SHOULD_PUSH_IMAGE == 'true' }}
+          type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+          type=raw,value=dev,enable=${{ github.ref == 'refs/heads/driver-service' }}
+          type=match,pattern=driver-service/v(.*),group=1
 
     - name: Login to GHCR
       if: ${{ env.SHOULD_PUSH_IMAGE == 'true' }}


### PR DESCRIPTION
This pull request updates the CI workflow for the driver service to better handle branch and tag-specific build and image tagging logic. The main improvements are in how CI is triggered and how Docker image tags are managed based on branch and tag names.

**Workflow trigger and image tagging improvements:**

* The workflow now triggers on both `push` and `pull_request` events for the `driver-service` and `main` branches, and also on tags matching `driver-service/v*` for pushes. (`.github/workflows/driver-service-ci.yml`)
* The Docker image tagging logic is updated to:
  - Tag images as `latest` only when pushing to `main`
  - Tag images as `dev` when pushing to `driver-service`
  - Tag images based on the version number when a tag matching `driver-service/v*` is pushed (`type=match,pattern=driver-service/v(.*),group=1`)
* The `SHOULD_PUSH_IMAGE` environment variable is simplified to be true for any push event, instead of only for pushes to `main`. (`.github/workflows/driver-service-ci.yml`)