### PR TITLE
ci(driver-service): restrict caching to push events for Python and Docker builds

### DIFF
--- a/.github/workflows/driver-service-ci.yml
+++ b/.github/workflows/driver-service-ci.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.13'
-          cache: 'pip'
+          cache: ${{ github.event_name == 'push' && 'pip' || '' }}
           cache-dependency-path: 'driver-service/requirements.txt'
 
       - name: Install dependencies
@@ -103,4 +103,4 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha,scope=driver-service
-        cache-to: type=gha,mode=max,scope=driver-service
+        cache-to: ${{ github.event_name == 'push' && 'type=gha,mode=max,scope=driver-service' || '' }}


### PR DESCRIPTION
This pull request updates the `driver-service` GitHub Actions workflow to optimize caching behavior based on the event type. The main goal is to ensure that dependency and Docker build caches are only saved during `push` events, which can help reduce unnecessary cache writes and improve workflow efficiency.

Workflow caching logic improvements:

* Changed the `setup-python` step to only enable pip caching when the workflow is triggered by a `push` event, avoiding cache writes on other event types. (`.github/workflows/driver-service-ci.yml`)
* Updated the Docker build step to only save the build cache (`cache-to`) when the workflow is triggered by a `push` event, preventing cache pollution from non-push events. (`.github/workflows/driver-service-ci.yml`)