### PR TITLE
ci(driver-service): update concurrency settings to cancel jobs only for pull requests

### DIFF
--- a/.github/workflows/driver-service-ci.yml
+++ b/.github/workflows/driver-service-ci.yml
@@ -27,7 +27,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test:


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration. The change ensures that in-progress workflow runs are only cancelled for pull request events, rather than for all events.

* Updated the `concurrency.cancel-in-progress` setting in `.github/workflows/driver-service-ci.yml` to conditionally cancel in-progress runs only when the event is a pull request.