### PR TITLE
fix: resolve invalid request body error in trip creation

### DIFF
--- a/client-gateway/bot/main.py
+++ b/client-gateway/bot/main.py
@@ -258,9 +258,24 @@ async def submit_trip_request(chat_id, order):
     """
     start_time = time.time()
     correlation_id = generate_correlation_id()
-    
-    # Generate deterministic UUID from chat_id for passenger_id
-    passenger_uuid = order.get('passenger_id') or str(uuid.uuid5(uuid.NAMESPACE_DNS, f"telegram-{chat_id}"))
+
+    # Validate and normalize passenger_id
+    provided_passenger_id = order.get('passenger_id')
+    if provided_passenger_id:
+        try:
+            # Validate it's a proper UUID format
+            uuid.UUID(str(provided_passenger_id))
+            passenger_uuid = str(provided_passenger_id)
+        except (ValueError, AttributeError):
+            # Invalid UUID, fall back to generated one
+            logger.warning(
+                "Invalid passenger_id provided: %s, generating deterministic UUID",
+                provided_passenger_id
+            )
+            passenger_uuid = str(uuid.uuid5(uuid.NAMESPACE_DNS, f"telegram-{chat_id}"))
+    else:
+        # No passenger_id provided, generate deterministic UUID from chat_id
+        passenger_uuid = str(uuid.uuid5(uuid.NAMESPACE_DNS, f"telegram-{chat_id}"))
 
     payload = {
         'pickup': order.get('pickup'),


### PR DESCRIPTION
- Remove 'comment' field from trip request payload (not in Trip schema)
- Generate valid UUID for passenger_id using uuid5 instead of raw chat_id
- Add detailed payload logging for debugging
- Import uuid module for UUID generation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Trip submissions now assign a consistent deterministic passenger identifier when none or an invalid one is provided, improving request correlation.
  * Submission logging now records a sanitized payload that masks personal and location details (addresses, pickup/dropoff, location) to protect user privacy while preserving useful troubleshooting data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->