### PR TITLE
feat: implement driver notification service and a consumer to process new trip events for driver assignment

### DIFF
--- a/driver-service/src/consumers/trip_events_consumer.py
+++ b/driver-service/src/consumers/trip_events_consumer.py
@@ -103,7 +103,7 @@ class TripEventsConsumer:
                 "comment": None
             }
             
-            notified_drivers = await self.notification_service.notify_nearby_drivers(
+            selected_driver_id = await self.notification_service.select_and_notify_driver(
                 trip_id=trip_id,
                 pickup_latitude=pickup_lat,
                 pickup_longitude=pickup_lng,
@@ -111,10 +111,10 @@ class TripEventsConsumer:
                 radius_km=5.0
             )
             
-            logger.info(
-                f"Trip {trip_id} processing complete. "
-                f"Notified {len(notified_drivers)} drivers: {notified_drivers}"
-            )
+            if selected_driver_id:
+                logger.info(f"Trip {trip_id} processing complete. Assigned search to driver: {selected_driver_id}")
+            else:
+                logger.warning(f"Trip {trip_id} processing complete. No driver selected/notified.")
             
         except Exception as e:
             logger.error(

--- a/driver-service/src/services/driver_notification_service.py
+++ b/driver-service/src/services/driver_notification_service.py
@@ -88,55 +88,61 @@ class DriverNotificationService:
         )
         return False
     
-    async def notify_nearby_drivers(
+    async def select_and_notify_driver(
         self,
         trip_id: str,
         pickup_latitude: float,
         pickup_longitude: float,
         notification_data: dict,
         radius_km: float = 5.0
-    ) -> List[str]:
-        """Find and notify nearby available drivers"""
+    ) -> str:
+        """
+        Select the best available driver and notify them.
+        Returns driver_id if successful, None otherwise.
+        """
         # Find nearby available drivers
         nearby_drivers = find_nearby_drivers(
             drivers=self.drivers,
             pickup_lat=pickup_latitude,
             pickup_lng=pickup_longitude,
             radius_km=radius_km,
-            max_drivers=10
+            max_drivers=10 # Get top 10 candidates
         )
         
         if not nearby_drivers:
-            logger.warning(f"No available drivers found for trip {trip_id}")
-            return []
+            logger.warning(
+                f"Selection failed: No available drivers found for trip {trip_id} "
+                f"within {radius_km}km"
+            )
+            return None
+            
+        # Select the 'best' driver (Simple algorithm: Nearest one)
+        selected_driver = nearby_drivers[0]
+        driver_id = selected_driver["id"]
         
         logger.info(
-            f"Found {len(nearby_drivers)} nearby drivers for trip {trip_id}"
+            f"Selected driver {driver_id} for trip {trip_id}. "
+            f"Distance: {selected_driver.get('distance_km')}km. "
+            f"Reason: Nearest available driver."
         )
         
-        notified_drivers = []
-        
-        # Send notifications to all nearby drivers
-        for driver in nearby_drivers:
-            driver_id = driver["id"]
-            
-            notification = TripRequestNotification(
-                trip_id=trip_id,
-                driver_id=driver_id,
-                **notification_data
-            )
-            
-            success = await self.send_trip_request_to_driver(
-                driver_id=driver_id,
-                notification=notification
-            )
-            
-            if success:
-                notified_drivers.append(driver_id)
-        
-        logger.info(
-            f"Successfully notified {len(notified_drivers)}/{len(nearby_drivers)} "
-            f"drivers for trip {trip_id}: {notified_drivers}"
+        # Notify the selected driver
+        notification = TripRequestNotification(
+            trip_id=trip_id,
+            driver_id=driver_id,
+            **notification_data
         )
         
-        return notified_drivers
+        success = await self.send_trip_request_to_driver(
+            driver_id=driver_id,
+            notification=notification
+        )
+        
+        if success:
+            logger.info(f"Successfully notified selected driver {driver_id} for trip {trip_id}")
+            return driver_id
+        else:
+            logger.error(f"Failed to notify selected driver {driver_id} for trip {trip_id}")
+            # In a real system, we would attempt to select the *next* driver here.
+            # For this simplified implementation, we just return None.
+            return None


### PR DESCRIPTION
This pull request refactors the driver notification logic to select and notify only the best available (nearest) driver for a trip, rather than notifying multiple nearby drivers. The main changes streamline the process by introducing a new method for driver selection and updating related logging and return values.

**Driver selection and notification logic:**

* Replaced the `notify_nearby_drivers` method with `select_and_notify_driver` in `driver_notification_service.py`, which now selects the nearest available driver and notifies only that driver, returning the driver's ID if successful.
* Updated the notification result handling in `select_and_notify_driver` to log success or failure for the selected driver and return either the driver's ID or `None`.

**Integration with trip event processing:**

* Updated `process_trip_created_event` in `trip_events_consumer.py` to use the new `select_and_notify_driver` method, and changed logging to reflect assignment to a single driver rather than notification of multiple drivers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated driver assignment logic to select and notify a single optimal driver per trip request instead of notifying multiple nearby drivers simultaneously, improving assignment efficiency and reducing redundant notifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->