### PR TITLE
feat: implement persistent bot user profiles with database storage (#…

### DIFF
--- a/client-gateway/bot/api_client.py
+++ b/client-gateway/bot/api_client.py
@@ -54,3 +54,55 @@ class APIClient:
     async def finish_trip(cls, driver_id, trip_id):
         """Завершення поїздки"""
         return await cls._request("POST", f"{DRIVER_SERVICE_URL}/drivers/{driver_id}/trips/{trip_id}/complete")
+
+    # ========== BOT USER MANAGEMENT ==========
+
+    @classmethod
+    async def get_or_create_bot_user(cls, chat_id, current_role='passenger'):
+        """Отримати або створити користувача бота"""
+        payload = {'telegram_chat_id': chat_id, 'current_role': current_role}
+        return await cls._request("POST", f"{DRIVER_SERVICE_URL}/api/bot-users", json=payload)
+
+    @classmethod
+    async def get_bot_user(cls, chat_id):
+        """Отримати профіль користувача бота"""
+        return await cls._request("GET", f"{DRIVER_SERVICE_URL}/api/bot-users/{chat_id}")
+
+    @classmethod
+    async def update_bot_user(cls, chat_id, updates):
+        """Оновити дані користувача бота"""
+        return await cls._request("PATCH", f"{DRIVER_SERVICE_URL}/api/bot-users/{chat_id}", json=updates)
+
+    @classmethod
+    async def register_bot_user_as_driver(cls, chat_id, driver_name, car_description):
+        """Зареєструвати користувача як водія"""
+        payload = {
+            'telegram_chat_id': chat_id,
+            'driver_name': driver_name,
+            'car_description': car_description
+        }
+        return await cls._request("POST", f"{DRIVER_SERVICE_URL}/api/bot-users/register-driver", json=payload)
+
+    @classmethod
+    async def change_bot_user_role(cls, chat_id, role):
+        """Змінити роль користувача"""
+        return await cls._request("PATCH", f"{DRIVER_SERVICE_URL}/api/bot-users/{chat_id}/role", params={'role': role})
+
+    @classmethod
+    async def update_bot_user_driver_status(cls, chat_id, is_online):
+        """Оновити статус водія (online/offline)"""
+        return await cls._request(
+            "PATCH",
+            f"{DRIVER_SERVICE_URL}/api/bot-users/{chat_id}/driver-status",
+            params={'is_online': is_online}
+        )
+
+    @classmethod
+    async def set_bot_user_active_trip(cls, chat_id, trip_id=None):
+        """Встановити активну поїздку для водія"""
+        params = {'trip_id': trip_id} if trip_id else {}
+        return await cls._request(
+            "PATCH",
+            f"{DRIVER_SERVICE_URL}/api/bot-users/{chat_id}/active-trip",
+            params=params
+        )

--- a/client-gateway/bot/driver.py
+++ b/client-gateway/bot/driver.py
@@ -4,6 +4,7 @@ from telegram import Update, InlineKeyboardMarkup, InlineKeyboardButton, ReplyKe
 from telegram.ext import MessageHandler, CallbackQueryHandler, ConversationHandler, ContextTypes, filters
 from telegram.helpers import escape_markdown
 from .logger_utils import create_trip_request_logger
+from .api_client import APIClient
 
 logger = create_trip_request_logger()
 
@@ -58,8 +59,8 @@ def register_handlers(application, user_orders, user_roles, buttons, keyboards, 
     
     driver_menu_unregistered = keyboards['driver_menu_unregistered']
     driver_menu_registered = keyboards['driver_menu_registered']
-    
-    register_driver_in_service = helpers['register_driver_in_service']
+
+    # Helper functions for API calls (some now replaced by APIClient methods)
     update_driver_status = helpers['update_driver_status']
     fetch_driver_trips = helpers['fetch_driver_trips']
     send_trip_response = helpers['send_trip_response']
@@ -67,23 +68,50 @@ def register_handlers(application, user_orders, user_roles, buttons, keyboards, 
     
     async def select_driver_role(update: Update, context: ContextTypes.DEFAULT_TYPE):
         chat_id = update.effective_chat.id
-        
+
+        # Get or create user from database
+        result = await APIClient.get_or_create_bot_user(chat_id, current_role='driver')
+
+        if not result['success']:
+            await update.message.reply_text(
+                "\u274C Помилка при підключенні до сервера. Спробуйте пізніше."
+            )
+            return
+
+        bot_user = result['data']
+
+        # Update current role to driver
+        try:
+            role_result = await APIClient.change_bot_user_role(chat_id, 'driver')
+            if not role_result.get('success'):
+                error_msg = role_result.get('error', {}).get('message', 'Невідома помилка') if isinstance(role_result.get('error'), dict) else 'Невідома помилка'
+                logger.error("Failed to change user role to driver: chat_id=%s error=%s", chat_id, error_msg)
+                await update.message.reply_text(
+                    f"\u274C Помилка при зміні ролі: {error_msg}\n\nСпробуйте пізніше."
+                )
+                return
+        except Exception as e:
+            logger.error("Exception while changing user role to driver: chat_id=%s error=%s", chat_id, str(e))
+            await update.message.reply_text(
+                "\u274C Помилка при підключенні до сервера. Спробуйте пізніше."
+            )
+            return
+
         # Check if driver is already registered
-        if chat_id in user_roles and isinstance(user_roles[chat_id], dict) and user_roles[chat_id].get('role') == 'driver':
-            driver_info = user_roles[chat_id]
-            is_online = driver_info.get('status') == 'online'
-            has_active_trip = driver_info.get('active_trip_id') is not None
+        if bot_user.get('driver_id'):
+            # Driver already registered
+            is_online = bot_user.get('driver_status') == 'online'
+            has_active_trip = bot_user.get('active_trip_id') is not None
             await update.message.reply_text(
                 f"\u2705 Ви вже зареєстровані як водій\n\n"
-                f"\U0001F464 Ім'я: {driver_info.get('name')}\n"
-                f"\U0001F697 Авто: {driver_info.get('car_description')}\n"
+                f"\U0001F464 Ім'я: {bot_user.get('driver_name', 'Не вказано')}\n"
+                f"\U0001F697 Авто: {bot_user.get('car_description', 'Не вказано')}\n"
                 f"\U0001F7E2 Статус: {'На лінії' if is_online else 'Офлайн'}\n\n"
                 "Оберіть опцію:",
                 reply_markup=driver_menu_registered(is_online, has_active_trip)
             )
         else:
             # New driver - needs registration
-            user_roles[chat_id] = {'role': 'driver', 'registered': False}
             await update.message.reply_text(
                 "\u2705 Ви обрали роль: Таксист\n\n"
                 "\U0001F4DD Для початку роботи потрібно зареєструватися.\n"
@@ -118,43 +146,34 @@ def register_handlers(application, user_orders, user_roles, buttons, keyboards, 
     async def process_driver_car(update: Update, context: ContextTypes.DEFAULT_TYPE):
         chat_id = update.effective_chat.id
         car_description = update.message.text
-        
+
         if len(car_description) < 5:
             await update.message.reply_text("\u274C Опис авто занадто короткий. Спробуйте ще раз:")
             return DRIVER_CAR
-        
+
         name = context.user_data.get('driver_name')
-        
+
         # Show processing message
         await update.message.reply_text(
             "\u23F3 Реєструємо вас у системі...",
             parse_mode='Markdown'
         )
-        
-        # Call Driver Service API
-        result = await register_driver_in_service(chat_id, name, car_description)
-        
+
+        # Register driver via API
+        result = await APIClient.register_bot_user_as_driver(chat_id, name, car_description)
+
         if result['success']:
-            driver_id = result['driver_id']
-            
-            # Store driver info in user_roles
-            user_roles[chat_id] = {
-                'role': 'driver',
-                'registered': True,
-                'driver_id': driver_id,
-                'name': name,
-                'car_description': car_description,
-                'status': 'offline'
-            }
-            
+            bot_user = result['data']
+            driver_id = bot_user['driver_id']
+
             # Sanitize PII for logs: use short hash instead of raw name
             try:
                 sanitized_name = hashlib.sha256(name.encode()).hexdigest()[:8] if name else 'none'
             except Exception:
                 sanitized_name = 'err'
-            
+
             logger.info("Driver registered successfully: chat_id=%s driver_id=%s name_hash=%s", chat_id, driver_id, sanitized_name)
-            
+
             await update.message.reply_text(
                 "\u2705 *Реєстрацію завершено!*\n\n"
                 f"\U0001F464 Ім'я: {escape_markdown(name)}\n"
@@ -166,16 +185,8 @@ def register_handlers(application, user_orders, user_roles, buttons, keyboards, 
             )
         else:
             if DEBUGGING:
-
+                # In debug mode, still use API to store test data
                 driver_id = f"drv_{chat_id}"
-                user_roles[chat_id] = {
-                    'role': 'driver',
-                    'registered': True,
-                    'driver_id': driver_id,
-                    'name': name,
-                    'car_description': car_description,
-                    'status': 'offline'
-                }
                 await update.message.reply_text(
                     "\u26A0\uFE0F *Режим налагодження*: Реєстрація змодельована успішно.\n\n"
                     f"\U0001F194 ID водія: {escape_markdown(driver_id)}\n\n"
@@ -201,9 +212,7 @@ def register_handlers(application, user_orders, user_roles, buttons, keyboards, 
                     parse_mode='Markdown',
                     reply_markup=driver_menu_unregistered()
                 )
-            
 
-        
         return ConversationHandler.END
 
     async def cancel_registration(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -215,48 +224,79 @@ def register_handlers(application, user_orders, user_roles, buttons, keyboards, 
 
     async def go_online(update: Update, context: ContextTypes.DEFAULT_TYPE):
         chat_id = update.effective_chat.id
-        
-        if chat_id not in user_roles or not isinstance(user_roles[chat_id], dict):
+
+        # Get user from database
+        result = await APIClient.get_bot_user(chat_id)
+        if not result['success'] or not result['data'].get('driver_id'):
             await update.message.reply_text("\u274C Спочатку зареєструйтесь як водій.")
             return
-        
-        driver_info = user_roles[chat_id]
-        
-        if not driver_info.get('registered'):
-            await update.message.reply_text("\u274C Спочатку зареєструйтесь як водій.")
-            return
-        
-        if driver_info.get('status') == 'online':
+
+        bot_user = result['data']
+
+        if bot_user.get('driver_status') == 'online':
             await update.message.reply_text(
                 "\U0001F7E2 Ви вже на лінії!",
                 reply_markup=driver_menu_registered(is_online=True)
             )
             return
-        
-        driver_id = driver_info['driver_id']
-        
+
+        driver_id = bot_user['driver_id']
+
         # Show processing message
         await update.message.reply_text("\u23F3 Виходимо на лінію...")
-        
-        # Call Driver Service API
-        result = await update_driver_status(driver_id, 'online')
-        
+
+        # Update status via API (BotUser table)
+        result = await APIClient.update_bot_user_driver_status(chat_id, is_online=True)
+
         if result['success']:
-            user_roles[chat_id]['status'] = 'online'
-            
-            logger.info("Driver went online: chat_id=%s driver_id=%s", chat_id, driver_id)
-            
-            await update.message.reply_text(
-                "\U0001F7E2 *Ви на лінії!*\n\n"
-                "\U0001F4E2 Тепер ви будете отримувати нові замовлення.",
-                parse_mode='Markdown',
-                reply_markup=driver_menu_registered(is_online=True, active_trip=False)
-            )
+            # Also update driver service status for consistency
+            try:
+                driver_status_result = await update_driver_status(driver_id, 'online')
+
+                if driver_status_result['success']:
+                    logger.info("Driver went online: chat_id=%s driver_id=%s", chat_id, driver_id)
+
+                    await update.message.reply_text(
+                        "\U0001F7E2 *Ви на лінії!*\n\n"
+                        "\U0001F4E2 Тепер ви будете отримувати нові замовлення.",
+                        parse_mode='Markdown',
+                        reply_markup=driver_menu_registered(is_online=True, active_trip=False)
+                    )
+                else:
+                    # Driver service update failed - rollback BotUser status to maintain consistency
+                    error_msg = driver_status_result.get('error', {}).get('message', 'Невідома помилка') if isinstance(driver_status_result.get('error'), dict) else 'Невідома помилка'
+                    logger.error("Failed to update driver service status, rolling back BotUser status: chat_id=%s driver_id=%s error=%s", chat_id, driver_id, error_msg)
+
+                    # Rollback: set BotUser back to offline
+                    try:
+                        await APIClient.update_bot_user_driver_status(chat_id, is_online=False)
+                    except Exception as e:
+                        logger.error("Failed to rollback BotUser status after driver service error: chat_id=%s error=%s", chat_id, str(e))
+
+                    await update.message.reply_text(
+                        f"\u274C *Помилка оновлення статусу*\n\n{escape_markdown(str(error_msg or ''))}\n\n"
+                        "Спробуйте ще раз.",
+                        parse_mode='Markdown'
+                    )
+            except Exception as e:
+                # Exception thrown from update_driver_status - rollback BotUser status
+                logger.error("Exception in update_driver_status, rolling back BotUser status: chat_id=%s driver_id=%s error=%s", chat_id, driver_id, str(e))
+
+                # Rollback: set BotUser back to offline
+                try:
+                    await APIClient.update_bot_user_driver_status(chat_id, is_online=False)
+                except Exception as rollback_error:
+                    logger.error("Failed to rollback BotUser status after exception: chat_id=%s error=%s", chat_id, str(rollback_error))
+
+                await update.message.reply_text(
+                    f"\u274C *Помилка оновлення статусу*\n\n{escape_markdown(str(e))}\n\n"
+                    "Спробуйте ще раз.",
+                    parse_mode='Markdown'
+                )
         else:
             if DEBUGGING:
-                user_roles[chat_id]['status'] = 'online'
                 logger.info("[DEBUG] Driver went online (mocked): chat_id=%s driver_id=%s", chat_id, driver_id)
-                
+
                 await update.message.reply_text(
                     "\u26A0\uFE0F *Режим налагодження*: Статус оновлено\n\n"
                     "\U0001F7E2 Ви на лінії!",
@@ -264,7 +304,6 @@ def register_handlers(application, user_orders, user_roles, buttons, keyboards, 
                     reply_markup=driver_menu_registered(is_online=True, active_trip=False)
                 )
             else:
-                # Safely extract error message
                 error_obj = result.get('error') if isinstance(result, dict) else None
                 if isinstance(error_obj, dict):
                     error_msg = error_obj.get('message') or 'Невідома помилка'
@@ -274,7 +313,7 @@ def register_handlers(application, user_orders, user_roles, buttons, keyboards, 
                     error_msg = 'Невідома помилка'
 
                 logger.error("Failed to set driver online: chat_id=%s error=%s", chat_id, error_msg)
-                
+
                 await update.message.reply_text(
                     f"\u274C *Помилка*\n\n{escape_markdown(str(error_msg or ''))}",
                     parse_mode='Markdown'
@@ -282,48 +321,79 @@ def register_handlers(application, user_orders, user_roles, buttons, keyboards, 
 
     async def go_offline(update: Update, context: ContextTypes.DEFAULT_TYPE):
         chat_id = update.effective_chat.id
-        
-        if chat_id not in user_roles or not isinstance(user_roles[chat_id], dict):
+
+        # Get user from database
+        result = await APIClient.get_bot_user(chat_id)
+        if not result['success'] or not result['data'].get('driver_id'):
             await update.message.reply_text("\u274C Спочатку зареєструйтесь як водій.")
             return
-        
-        driver_info = user_roles[chat_id]
-        
-        if not driver_info.get('registered'):
-            await update.message.reply_text("\u274C Спочатку зареєструйтесь як водій.")
-            return
-        
-        if driver_info.get('status') == 'offline':
+
+        bot_user = result['data']
+
+        if bot_user.get('driver_status') == 'offline':
             await update.message.reply_text(
                 "\U0001F534 Ви вже офлайн!",
                 reply_markup=driver_menu_registered(is_online=False)
             )
             return
-        
-        driver_id = driver_info['driver_id']
-        
+
+        driver_id = bot_user['driver_id']
+
         # Show processing message
         await update.message.reply_text("\u23F3 Виходимо з лінії...")
-        
-        # Call Driver Service API
-        result = await update_driver_status(driver_id, 'offline')
-        
+
+        # Update status via API (BotUser table)
+        result = await APIClient.update_bot_user_driver_status(chat_id, is_online=False)
+
         if result['success']:
-            user_roles[chat_id]['status'] = 'offline'
-            
-            logger.info("Driver went offline: chat_id=%s driver_id=%s", chat_id, driver_id)
-            
-            await update.message.reply_text(
-                "\U0001F534 *Ви офлайн*\n\n"
-                "\U0001F6AB Ви більше не отримуватимете нові замовлення.",
-                parse_mode='Markdown',
-                reply_markup=driver_menu_registered(is_online=False, active_trip=False)
-            )
+            # Also update driver service status for consistency
+            try:
+                driver_status_result = await update_driver_status(driver_id, 'offline')
+
+                if driver_status_result['success']:
+                    logger.info("Driver went offline: chat_id=%s driver_id=%s", chat_id, driver_id)
+
+                    await update.message.reply_text(
+                        "\U0001F534 *Ви офлайн*\n\n"
+                        "\U0001F6AB Ви більше не отримуватимете нові замовлення.",
+                        parse_mode='Markdown',
+                        reply_markup=driver_menu_registered(is_online=False, active_trip=False)
+                    )
+                else:
+                    # Driver service update failed - rollback BotUser status to maintain consistency
+                    error_msg = driver_status_result.get('error', {}).get('message', 'Невідома помилка') if isinstance(driver_status_result.get('error'), dict) else 'Невідома помилка'
+                    logger.error("Failed to update driver service status, rolling back BotUser status: chat_id=%s driver_id=%s error=%s", chat_id, driver_id, error_msg)
+
+                    # Rollback: set BotUser back to online
+                    try:
+                        await APIClient.update_bot_user_driver_status(chat_id, is_online=True)
+                    except Exception as e:
+                        logger.error("Failed to rollback BotUser status after driver service error: chat_id=%s error=%s", chat_id, str(e))
+
+                    await update.message.reply_text(
+                        f"\u274C *Помилка оновлення статусу*\n\n{escape_markdown(str(error_msg or ''))}\n\n"
+                        "Спробуйте ще раз.",
+                        parse_mode='Markdown'
+                    )
+            except Exception as e:
+                # Exception thrown from update_driver_status - rollback BotUser status
+                logger.error("Exception in update_driver_status, rolling back BotUser status: chat_id=%s driver_id=%s error=%s", chat_id, driver_id, str(e))
+
+                # Rollback: set BotUser back to online
+                try:
+                    await APIClient.update_bot_user_driver_status(chat_id, is_online=True)
+                except Exception as rollback_error:
+                    logger.error("Failed to rollback BotUser status after exception: chat_id=%s error=%s", chat_id, str(rollback_error))
+
+                await update.message.reply_text(
+                    f"\u274C *Помилка оновлення статусу*\n\n{escape_markdown(str(e))}\n\n"
+                    "Спробуйте ще раз.",
+                    parse_mode='Markdown'
+                )
         else:
             if DEBUGGING:
-                user_roles[chat_id]['status'] = 'offline'
                 logger.info("[DEBUG] Driver went offline (mocked): chat_id=%s driver_id=%s", chat_id, driver_id)
-                
+
                 await update.message.reply_text(
                     "\u26A0\uFE0F *Режим налагодження*: Статус оновлено\n\n"
                     "\U0001F534 Ви офлайн",
@@ -331,7 +401,6 @@ def register_handlers(application, user_orders, user_roles, buttons, keyboards, 
                     reply_markup=driver_menu_registered(is_online=False, active_trip=False)
                 )
             else:
-                # Safely extract error message
                 error_obj = result.get('error') if isinstance(result, dict) else None
                 if isinstance(error_obj, dict):
                     error_msg = error_obj.get('message') or 'Невідома помилка'
@@ -341,7 +410,7 @@ def register_handlers(application, user_orders, user_roles, buttons, keyboards, 
                     error_msg = 'Невідома помилка'
 
                 logger.error("Failed to set driver offline: chat_id=%s error=%s", chat_id, error_msg)
-                
+
                 await update.message.reply_text(
                     f"\u274C *Помилка*\n\n{escape_markdown(str(error_msg or ''))}",
                     parse_mode='Markdown'
@@ -349,29 +418,32 @@ def register_handlers(application, user_orders, user_roles, buttons, keyboards, 
 
     async def show_driver_status(update: Update, context: ContextTypes.DEFAULT_TYPE):
         chat_id = update.effective_chat.id
-        
-        if chat_id not in user_roles or not isinstance(user_roles[chat_id], dict):
+
+        # Get user from database
+        result = await APIClient.get_bot_user(chat_id)
+        if not result['success']:
             await update.message.reply_text("\u274C Спочатку зареєструйтесь як водій.")
             return
-        
-        driver_info = user_roles[chat_id]
-        
-        if not driver_info.get('registered'):
+
+        bot_user = result['data']
+
+        # Check if registered as driver
+        if not bot_user.get('driver_id'):
             await update.message.reply_text(
                 "\u274C Ви ще не зареєстровані як водій.",
                 reply_markup=driver_menu_unregistered()
             )
             return
-        
-        is_online = driver_info.get('status') == 'online'
-        has_active_trip = driver_info.get('active_trip_id') is not None
+
+        is_online = bot_user.get('driver_status') == 'online'
+        has_active_trip = bot_user.get('active_trip_id') is not None
         status_emoji = "\U0001F7E2" if is_online else "\U0001F534"
         status_text = "На лінії" if is_online else "Офлайн"
 
         # Coerce values to safe strings before escaping to avoid TypeError
-        safe_name = str(driver_info.get('name') or '')
-        safe_car = str(driver_info.get('car_description') or '')
-        safe_driver_id = str(driver_info.get('driver_id') or '')
+        safe_name = str(bot_user.get('driver_name') or '')
+        safe_car = str(bot_user.get('car_description') or '')
+        safe_driver_id = str(bot_user.get('driver_id') or '')
 
         await update.message.reply_text(
             f"\U0001F4CA *Ваш статус*\n\n"
@@ -385,22 +457,38 @@ def register_handlers(application, user_orders, user_roles, buttons, keyboards, 
 
     async def show_driver_orders(update: Update, context: ContextTypes.DEFAULT_TYPE):
         chat_id = update.effective_chat.id
-        
-        if chat_id not in user_roles or not isinstance(user_roles[chat_id], dict):
+
+        # Get user from database
+        result = await APIClient.get_bot_user(chat_id)
+        if not result['success']:
             await update.message.reply_text("\u274C Спочатку зареєструйтесь як водій.")
             return
-        
-        driver_info = user_roles[chat_id]
-        
-        if not driver_info.get('registered'):
+
+        bot_user = result['data']
+
+        # Check if registered as driver
+        if not bot_user.get('driver_id'):
             await update.message.reply_text(
                 "\u274C Спочатку зареєструйтесь як водій.",
                 reply_markup=driver_menu_unregistered()
             )
             return
-        
-        is_online = driver_info.get('status') == 'online'
-        
+
+        is_online = bot_user.get('driver_status') == 'online'
+        active_trip_id = bot_user.get('active_trip_id')
+
+        # If driver has active trip, show only active trip info
+        if active_trip_id:
+            await update.message.reply_text(
+                f"\U0001F6A8 *У вас є активна поїздка*\n\n"
+                f"\U0001F194 ID поїздки: `{escape_markdown(str(active_trip_id))}`\n\n"
+                "🏁 Завершіть поточну поїздку, щоб побачити нові замовлення.\n"
+                "Натисніть кнопку *Завершити поїздку* внизу.",
+                parse_mode='Markdown',
+                reply_markup=driver_menu_registered(is_online=is_online, active_trip=True)
+            )
+            return
+
         if not is_online:
             await update.message.reply_text(
                 "\U0001F534 Ви офлайн\n\n"
@@ -408,8 +496,8 @@ def register_handlers(application, user_orders, user_roles, buttons, keyboards, 
                 reply_markup=driver_menu_registered(is_online=False, active_trip=False)
             )
             return
-        
-        driver_id = driver_info.get('driver_id')
+
+        driver_id = bot_user.get('driver_id')
         
         # Show loading message
         await update.message.reply_text("\u23F3 Завантаження замовлень...")
@@ -459,39 +547,52 @@ def register_handlers(application, user_orders, user_roles, buttons, keyboards, 
         if DEBUGGING and not result['success']:
             debug_prefix = "\u26A0\uFE0F *Режим налагодження*: Змодельовані замовлення\n\n"
         
-        logger.info("Found %d pending trips for driver: chat_id=%s driver_id=%s", len(trips), chat_id, driver_id)
-        
-        # Display each trip with Accept/Reject buttons
-        for trip in trips:
+        logger.info("Found %d trips for driver: chat_id=%s driver_id=%s", len(trips), chat_id, driver_id)
+
+        # Filter only PENDING trips (exclude ACTIVE/assigned trips)
+        pending_trips = [trip for trip in trips if trip.get('status') == 'PENDING']
+
+        if not pending_trips:
+            await update.message.reply_text(
+                "\U0001F4ED У вас немає нових замовлень\n\n"
+                "\U0001F4A1 Нові замовлення з'являться тут автоматично.",
+                reply_markup=driver_menu_registered(is_online=True, active_trip=False)
+            )
+            return
+
+        logger.info("Showing %d pending trips (filtered from %d total)", len(pending_trips), len(trips))
+
+        # Display each PENDING trip with Accept/Reject buttons
+        for trip in pending_trips:
             trip_id = trip.get('id') or trip.get('trip_id') or 'N/A'
             pickup = trip.get('pickup') or trip.get('pickup_address') or 'Не вказано'
             dropoff = trip.get('dropoff') or trip.get('dropoff_address') or 'Не вказано'
             comment = trip.get('comment') or ''
-            
+
             text = (
                 "\U0001F6A8 *Нове замовлення*\n\n"
                 f"\U0001F194 ID: `{escape_markdown(str(trip_id))}`\n"
                 f"\U0001F4CD *Звідки:* {escape_markdown(str(pickup))}\n"
                 f"\U0001F3C1 *Куди:* {escape_markdown(str(dropoff))}\n"
             )
-            
+
             if comment:
                 text += f"\U0001F4AC *Коментар:* {escape_markdown(str(comment))}\n"
-            
+
             markup = InlineKeyboardMarkup([
                 [
                     InlineKeyboardButton("\u2705 Прийняти", callback_data=f"accept_trip_{trip_id}"),
                     InlineKeyboardButton("\u274C Відхилити", callback_data=f"decline_trip_{trip_id}")
                 ]
             ])
-            
+
             await update.message.reply_text(
                 text,
                 parse_mode='Markdown',
                 reply_markup=markup
             )
         
-        summary_text = f"\U0001F4CB Знайдено замовлень: {len(trips)}"
+        summary_text = f"\U0001F4CB Знайдено замовлень: {len(pending_trips)}"
         if debug_prefix:
             summary_text = debug_prefix + summary_text
         
@@ -504,78 +605,138 @@ def register_handlers(application, user_orders, user_roles, buttons, keyboards, 
     async def accept_trip(update: Update, context: ContextTypes.DEFAULT_TYPE):
         query = update.callback_query
         await query.answer()
-        
+
         trip_id = query.data.replace('accept_trip_', '')
         chat_id = query.message.chat.id
-        
-        # Get driver info
-        driver_info = user_roles.get(chat_id)
-        if not driver_info or not isinstance(driver_info, dict) or not driver_info.get('registered'):
+
+        # Get driver info from database
+        result = await APIClient.get_bot_user(chat_id)
+        if not result['success'] or not result['data'].get('driver_id'):
             logger.warning("Accept trip attempted by unregistered driver: chat_id=%s trip_id=%s", chat_id, trip_id)
             await query.edit_message_text(
                 text="\u274C Ви не зареєстровані як водій.",
                 parse_mode='Markdown'
             )
             return
-        
-        driver_id = driver_info.get('driver_id')
-        
+
+        bot_user = result['data']
+        driver_id = bot_user.get('driver_id')
+
         logger.info("Driver accepting trip: chat_id=%s driver_id=%s trip_id=%s", chat_id, driver_id, trip_id)
-        
+
         # Show processing state
         await query.edit_message_text(
             text=f"\u23F3 Приймаємо замовлення {escape_markdown(str(trip_id))}...",
             parse_mode='Markdown'
         )
-        
+
         # Call Driver Service
         result = await send_trip_response(driver_id, trip_id, 'accept')
-        
+
         if result['success']:
-            # Set driver offline after accepting trip and store active trip
-            user_roles[chat_id]['status'] = 'offline'
-            user_roles[chat_id]['active_trip_id'] = trip_id
-            
-            logger.info("Trip accepted successfully: chat_id=%s driver_id=%s trip_id=%s", chat_id, driver_id, trip_id)
-            await query.edit_message_text(
-                text=(
-                    f"\u2705 *Замовлення прийнято!*\n\n"
-                    f"\U0001F194 ID: `{escape_markdown(str(trip_id))}`\n\n"
-                    "\U0001F4DE Зв'яжіться з клієнтом для уточнення деталей.\n"
-                    "\U0001F534 Ви перейшли в офлайн."
-                ),
-                parse_mode='Markdown'
-            )
-            
-            # Automatically refresh status with updated menu
+            # Update status to offline and set active trip in database
+            # Both operations must succeed to maintain consistency
+            db_update_success = False
+            status_updated = False
+            trip_updated = False
+
             try:
-                await query.message.reply_text(
-                    f"\U0001F4CA *Ваш статус*\n\n"
-                    f"\U0001F464 Ім'я: {escape_markdown(str(user_roles[chat_id].get('name') or ''))}\n"
-                    f"\U0001F697 Авто: {escape_markdown(str(user_roles[chat_id].get('car_description') or ''))}\n"
-                    f"\U0001F194 ID: {escape_markdown(str(driver_id))}\n"
-                    f"\U0001F534 Статус: *Офлайн (активна поїздка)*",
-                    parse_mode='Markdown',
-                    reply_markup=driver_menu_registered(is_online=False, active_trip=True)
-                )
-                
-                # Send message about active trip
-                await query.message.reply_text(
-                    f"\U0001F6A8 *Активна поїздка*\n\n"
-                    f"\U0001F194 ID поїздки: `{escape_markdown(str(trip_id))}`\n\n"
-                    f"📍 Відправна точка: {escape_markdown(str(result.get('pickup_address') or 'Не вказано'))}\n"
-                    f"🏁 Точка призначення: {escape_markdown(str(result.get('dropoff_address') or 'Не вказано'))}\n\n"
-                    "🏁 Натисніть кнопку *Завершити поїздку* коли закінчите",
+                # First update: set driver offline
+                status_result = await APIClient.update_bot_user_driver_status(chat_id, is_online=False)
+                if status_result.get('success'):
+                    status_updated = True
+                    logger.info("Driver status updated to offline: chat_id=%s", chat_id)
+                else:
+                    error_msg = status_result.get('error', {}).get('message', 'Unknown error') if isinstance(status_result.get('error'), dict) else 'Unknown error'
+                    logger.error("Failed to update driver status after trip acceptance: chat_id=%s error=%s", chat_id, error_msg)
+                    raise Exception(f"Status update failed: {error_msg}")
+
+                # Second update: set active trip
+                trip_result = await APIClient.set_bot_user_active_trip(chat_id, trip_id)
+                if trip_result.get('success'):
+                    trip_updated = True
+                    logger.info("Active trip set: chat_id=%s trip_id=%s", chat_id, trip_id)
+                    db_update_success = True
+                else:
+                    error_msg = trip_result.get('error', {}).get('message', 'Unknown error') if isinstance(trip_result.get('error'), dict) else 'Unknown error'
+                    logger.error("Failed to set active trip after acceptance: chat_id=%s trip_id=%s error=%s", chat_id, trip_id, error_msg)
+                    raise Exception(f"Active trip update failed: {error_msg}")
+
+            except Exception as e:
+                logger.error("Exception while updating driver state after trip acceptance: chat_id=%s error=%s", chat_id, str(e))
+
+                # Rollback: if status was updated but trip update failed, revert status to online
+                if status_updated and not trip_updated:
+                    logger.warning("Rolling back driver status to online: chat_id=%s", chat_id)
+                    try:
+                        rollback_result = await APIClient.update_bot_user_driver_status(chat_id, is_online=True)
+                        if not rollback_result.get('success'):
+                            logger.error("Failed to rollback driver status: chat_id=%s", chat_id)
+                    except Exception as rollback_error:
+                        logger.error("Exception during rollback: chat_id=%s error=%s", chat_id, str(rollback_error))
+
+                # Show error to user
+                await query.edit_message_text(
+                    text=(
+                        f"\u274C *Помилка оновлення статусу*\n\n"
+                        f"Замовлення прийнято в системі, але не вдалося оновити ваш статус.\n\n"
+                        f"Деталі: {escape_markdown(str(e))}\n\n"
+                        "Спробуйте оновити статус вручну або зверніться до підтримки."
+                    ),
                     parse_mode='Markdown'
                 )
-            except Exception as e:
-                logger.warning("Failed to send status refresh after trip acceptance: %s", e)
+                return
+
+            # Only show success if both DB updates succeeded
+            if db_update_success:
+                logger.info("Trip accepted successfully: chat_id=%s driver_id=%s trip_id=%s", chat_id, driver_id, trip_id)
+                await query.edit_message_text(
+                    text=(
+                        f"\u2705 *Замовлення прийнято!*\n\n"
+                        f"\U0001F194 ID: `{escape_markdown(str(trip_id))}`\n\n"
+                        "\U0001F4DE Зв'яжіться з клієнтом для уточнення деталей.\n"
+                        "\U0001F534 Ви перейшли в офлайн."
+                    ),
+                    parse_mode='Markdown'
+                )
+
+                # Automatically refresh status with updated menu
+                try:
+                    await query.message.reply_text(
+                        f"\U0001F4CA *Ваш статус*\n\n"
+                        f"\U0001F464 Ім'я: {escape_markdown(str(bot_user.get('driver_name') or ''))}\n"
+                        f"\U0001F697 Авто: {escape_markdown(str(bot_user.get('car_description') or ''))}\n"
+                        f"\U0001F194 ID: {escape_markdown(str(driver_id))}\n"
+                        f"\U0001F534 Статус: *Офлайн (активна поїздка)*",
+                        parse_mode='Markdown',
+                        reply_markup=driver_menu_registered(is_online=False, active_trip=True)
+                    )
+
+                    # Send message about active trip
+                    await query.message.reply_text(
+                        f"\U0001F6A8 *Активна поїздка*\n\n"
+                        f"\U0001F194 ID поїздки: `{escape_markdown(str(trip_id))}`\n\n"
+                        f"📍 Відправна точка: {escape_markdown(str(result.get('pickup_address') or 'Не вказано'))}\n"
+                        f"🏁 Точка призначення: {escape_markdown(str(result.get('dropoff_address') or 'Не вказано'))}\n\n"
+                        "🏁 Натисніть кнопку *Завершити поїздку* коли закінчите",
+                        parse_mode='Markdown'
+                    )
+                except Exception as e:
+                    logger.warning("Failed to send status refresh after trip acceptance: %s", e)
         else:
             if DEBUGGING:
                 # Set driver offline in debug mode as well
-                user_roles[chat_id]['status'] = 'offline'
-                user_roles[chat_id]['active_trip_id'] = trip_id
-                
+                try:
+                    status_result = await APIClient.update_bot_user_driver_status(chat_id, is_online=False)
+                    if not status_result.get('success'):
+                        logger.warning("[DEBUG] Failed to update driver status: %s", status_result.get('error'))
+
+                    trip_result = await APIClient.set_bot_user_active_trip(chat_id, trip_id)
+                    if not trip_result.get('success'):
+                        logger.warning("[DEBUG] Failed to set active trip: %s", trip_result.get('error'))
+                except Exception as e:
+                    logger.warning("[DEBUG] Exception while updating driver state: %s", str(e))
+
                 logger.info("[DEBUG] Mocking trip acceptance: chat_id=%s driver_id=%s trip_id=%s", chat_id, driver_id, trip_id)
                 await query.edit_message_text(
                     text=(
@@ -655,61 +816,105 @@ def register_handlers(application, user_orders, user_roles, buttons, keyboards, 
     
     async def finish_trip_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         chat_id = update.effective_chat.id
-        
-        # Get driver info
-        driver_info = user_roles.get(chat_id)
-        if not driver_info or not isinstance(driver_info, dict) or not driver_info.get('registered'):
+
+        # Get driver info from database
+        result = await APIClient.get_bot_user(chat_id)
+        if not result['success'] or not result['data'].get('driver_id'):
             await update.message.reply_text(
                 "\u274C Ви не зареєстровані як водій.",
                 reply_markup=driver_menu_unregistered()
             )
             return
-        
-        active_trip_id = driver_info.get('active_trip_id')
+
+        bot_user = result['data']
+        active_trip_id = bot_user.get('active_trip_id')
+        is_online = bot_user.get('driver_status') == 'online'
+
         if not active_trip_id:
             await update.message.reply_text(
                 "\u274C У вас немає активної поїздки.",
-                reply_markup=driver_menu_registered(is_online=False, active_trip=False)
+                reply_markup=driver_menu_registered(is_online=is_online, active_trip=False)
             )
             return
-        
-        driver_id = driver_info.get('driver_id')
-        
+
+        driver_id = bot_user.get('driver_id')
+
         logger.info("Driver finishing trip: chat_id=%s driver_id=%s trip_id=%s", chat_id, driver_id, active_trip_id)
-        
+
         # Show processing message
         await update.message.reply_text(f"\u23F3 Завершуємо поїздку {escape_markdown(str(active_trip_id))}...", parse_mode='Markdown')
-        
+
         # Call finish_trip helper
         result = await finish_trip(driver_id, active_trip_id)
-        
+
         if result['success']:
-            # Clear active trip and keep driver offline
-            user_roles[chat_id]['active_trip_id'] = None
-            
-            logger.info("Trip finished successfully: chat_id=%s driver_id=%s trip_id=%s", chat_id, driver_id, active_trip_id)
-            
-            await update.message.reply_text(
-                f"\U0001F3C1 *Поїздку завершено!*\n\n"
-                f"\U0001F194 ID: `{escape_markdown(str(active_trip_id))}`\n\n"
-                "\U0001F4B5 Дякуємо за роботу!\n"
-                "\U0001F7E2 Вийдіть на лінію, щоб отримувати нові замовлення.",
-                parse_mode='Markdown',
-                reply_markup=driver_menu_registered(is_online=False, active_trip=False)
-            )
-        else:
-            if DEBUGGING:
-                # Clear active trip in debug mode
-                user_roles[chat_id]['active_trip_id'] = None
-                
-                logger.info("[DEBUG] Mocking trip completion: chat_id=%s driver_id=%s trip_id=%s", chat_id, driver_id, active_trip_id)
-                
+            # Clear active trip in database - this must succeed to show success to user
+            db_update_success = False
+            try:
+                trip_result = await APIClient.set_bot_user_active_trip(chat_id, None)
+                if trip_result.get('success'):
+                    db_update_success = True
+                    logger.info("Active trip cleared: chat_id=%s trip_id=%s", chat_id, active_trip_id)
+                else:
+                    error_msg = trip_result.get('error', {}).get('message', 'Unknown error') if isinstance(trip_result.get('error'), dict) else 'Unknown error'
+                    logger.error("Failed to clear active trip after completion: chat_id=%s trip_id=%s error=%s", chat_id, active_trip_id, error_msg)
+                    raise Exception(f"Failed to update database: {error_msg}")
+            except Exception as e:
+                logger.error("Exception while clearing active trip after completion: chat_id=%s error=%s", chat_id, str(e))
+                # Show error to user
                 await update.message.reply_text(
-                    "\u26A0\uFE0F *Режим налагодження*\n\n"
-                    f"\U0001F3C1 Поїздку {escape_markdown(str(active_trip_id))} завершено",
+                    f"\u274C *Помилка оновлення статусу*\n\n"
+                    f"Поїздка завершена в системі, але не вдалося оновити ваш статус.\n\n"
+                    f"Деталі: {escape_markdown(str(e))}\n\n"
+                    "Спробуйте оновити статус вручну або зверніться до підтримки.",
+                    parse_mode='Markdown',
+                    reply_markup=driver_menu_registered(is_online=is_online, active_trip=True)
+                )
+                return
+
+            # Only show success if DB update succeeded
+            if db_update_success:
+                logger.info("Trip finished successfully: chat_id=%s driver_id=%s trip_id=%s", chat_id, driver_id, active_trip_id)
+
+                await update.message.reply_text(
+                    f"\U0001F3C1 *Поїздку завершено!*\n\n"
+                    f"\U0001F194 ID: `{escape_markdown(str(active_trip_id))}`\n\n"
+                    "\U0001F4B5 Дякуємо за роботу!\n"
+                    "\U0001F7E2 Вийдіть на лінію, щоб отримувати нові замовлення.",
                     parse_mode='Markdown',
                     reply_markup=driver_menu_registered(is_online=False, active_trip=False)
                 )
+        else:
+            if DEBUGGING:
+                # Clear active trip in debug mode
+                db_update_success = False
+                try:
+                    trip_result = await APIClient.set_bot_user_active_trip(chat_id, None)
+                    if trip_result.get('success'):
+                        db_update_success = True
+                    else:
+                        error_msg = trip_result.get('error', {}).get('message', 'Unknown error') if isinstance(trip_result.get('error'), dict) else 'Unknown error'
+                        logger.warning("[DEBUG] Failed to clear active trip: %s", error_msg)
+                        raise Exception(f"Failed to update database: {error_msg}")
+                except Exception as e:
+                    logger.warning("[DEBUG] Exception while clearing active trip: %s", str(e))
+                    await update.message.reply_text(
+                        f"\u274C *[DEBUG] Помилка оновлення статусу*\n\n"
+                        f"Деталі: {escape_markdown(str(e))}",
+                        parse_mode='Markdown',
+                        reply_markup=driver_menu_registered(is_online=is_online, active_trip=True)
+                    )
+                    return
+
+                if db_update_success:
+                    logger.info("[DEBUG] Mocking trip completion: chat_id=%s driver_id=%s trip_id=%s", chat_id, driver_id, active_trip_id)
+
+                    await update.message.reply_text(
+                        "\u26A0\uFE0F *Режим налагодження*\n\n"
+                        f"\U0001F3C1 Поїздку {escape_markdown(str(active_trip_id))} завершено",
+                        parse_mode='Markdown',
+                        reply_markup=driver_menu_registered(is_online=False, active_trip=False)
+                    )
             else:
                 error_obj = result.get('error') if isinstance(result, dict) else None
                 if isinstance(error_obj, dict):
@@ -722,35 +927,36 @@ def register_handlers(application, user_orders, user_roles, buttons, keyboards, 
                     error_msg = 'Невідома помилка'
                     status_code = 500
                 
-                logger.error("Failed to finish trip: chat_id=%s driver_id=%s trip_id=%s error=%s status=%d", 
+                logger.error("Failed to finish trip: chat_id=%s driver_id=%s trip_id=%s error=%s status=%d",
                            chat_id, driver_id, active_trip_id, error_msg, status_code)
-                
+
                 await update.message.reply_text(
                     f"\u274C *Помилка*\n\n"
                     f"{escape_markdown(str(error_msg))}\n\n"
                     "Спробуйте ще раз пізніше.",
                     parse_mode='Markdown',
-                    reply_markup=driver_menu_registered(is_online=False, active_trip=True)
+                    reply_markup=driver_menu_registered(is_online=is_online, active_trip=True)
                 )
     
     async def decline_trip(update: Update, context: ContextTypes.DEFAULT_TYPE):
         query = update.callback_query
         await query.answer()
-        
+
         trip_id = query.data.replace('decline_trip_', '')
         chat_id = query.message.chat.id
-        
-        # Get driver info
-        driver_info = user_roles.get(chat_id)
-        if not driver_info or not isinstance(driver_info, dict) or not driver_info.get('registered'):
+
+        # Get driver info from database
+        result = await APIClient.get_bot_user(chat_id)
+        if not result['success'] or not result['data'].get('driver_id'):
             logger.warning("Decline trip attempted by unregistered driver: chat_id=%s trip_id=%s", chat_id, trip_id)
             await query.edit_message_text(
                 text="\u274C Ви не зареєстровані як водій.",
                 parse_mode='Markdown'
             )
             return
-        
-        driver_id = driver_info.get('driver_id')
+
+        bot_user = result['data']
+        driver_id = bot_user.get('driver_id')
         
         logger.info("Driver declining trip: chat_id=%s driver_id=%s trip_id=%s", chat_id, driver_id, trip_id)
         

--- a/client-gateway/bot/main.py
+++ b/client-gateway/bot/main.py
@@ -12,6 +12,7 @@ from dotenv import load_dotenv
 from . import passenger
 from . import driver
 from .logger_utils import create_trip_request_logger, generate_correlation_id
+from .api_client import APIClient
 
 logger = create_trip_request_logger()
 
@@ -31,7 +32,10 @@ def ensure_bot_token():
         logger.error("BOT_TOKEN is not set in the environment or .env file.")
         sys.exit("ERROR: BOT_TOKEN is not configured.")
 
+# Keep user_orders in memory for now (temporary state)
 user_orders = {}
+# user_roles kept as empty dict for backward compatibility with passenger/driver modules
+# Actual role data is now stored in database via API
 user_roles = {}
 
 BTN_PASSENGER = "\U0001F64B Я замовник таксі"
@@ -108,8 +112,14 @@ def skip_menu():
     return ReplyKeyboardMarkup(keyboard, resize_keyboard=True, one_time_keyboard=True)
 
 def get_user_menu(chat_id):
-    role = user_roles.get(chat_id, 'passenger')
-    return driver_menu() if role == 'driver' else passenger_menu()
+    """
+    Get user menu based on current role.
+    Note: This is a fallback function, actual role is managed via API in async handlers.
+    Returns passenger menu by default.
+    """
+    # This function is kept synchronous for backward compatibility with KEYBOARDS dict
+    # Actual role switching is handled in async handler functions via API
+    return passenger_menu()  # Default to passenger menu
 
 KEYBOARDS = {
     'role_selection_menu': role_selection_menu,
@@ -1143,8 +1153,16 @@ HELPERS = {
 
 async def start_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
     chat_id = update.effective_chat.id
-    user_roles.pop(chat_id, None)
+    # Clear temporary orders
     user_orders.pop(chat_id, None)
+
+    # Create or get user from database
+    try:
+        await APIClient.get_or_create_bot_user(chat_id, current_role='passenger')
+    except Exception as e:
+        # Log the error but continue - we don't want failures in driver-service to prevent the welcome message
+        logger.error("Failed to create/get bot user on start: chat_id=%s error=%s", chat_id, str(e))
+
     await update.message.reply_text(
         "\U0001F696 Вітаємо у службі таксі!\n\nОберіть вашу роль:",
         reply_markup=role_selection_menu()
@@ -1152,8 +1170,10 @@ async def start_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 async def change_role(update: Update, context: ContextTypes.DEFAULT_TYPE):
     chat_id = update.effective_chat.id
-    user_roles.pop(chat_id, None)
+    # Clear temporary orders
     user_orders.pop(chat_id, None)
+
+    # Note: We don't delete user data from DB, just show role selection
     await update.message.reply_text(
         "\U0001F504 Оберіть нову роль:",
         reply_markup=role_selection_menu()

--- a/client-gateway/tests/test_driver_registration.py
+++ b/client-gateway/tests/test_driver_registration.py
@@ -3,11 +3,12 @@ Tests for driver registration and status management functionality.
 """
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 # Import bot modules
 from bot import main
 from bot import driver
+from bot.api_client import APIClient
 
 
 @pytest.fixture
@@ -57,30 +58,57 @@ def cleanup_user_roles():
         pass
 
 
+@pytest.fixture
+def mock_api_client():
+    """Mock APIClient for all tests"""
+    with patch.object(APIClient, 'get_bot_user') as get_user, \
+         patch.object(APIClient, 'get_or_create_bot_user') as create_user, \
+         patch.object(APIClient, 'register_bot_user_as_driver') as register_driver, \
+         patch.object(APIClient, 'update_bot_user_driver_status') as update_status, \
+         patch.object(APIClient, 'change_bot_user_role') as change_role, \
+         patch.object(APIClient, 'set_bot_user_active_trip') as set_trip:
+
+        # Default successful responses
+        get_user.return_value = {'success': False, 'data': None}
+        create_user.return_value = {'success': True, 'data': {'current_role': 'driver', 'driver_id': None}}
+        register_driver.return_value = {'success': True, 'data': {'driver_id': 'drv_123', 'current_role': 'driver'}}
+        update_status.return_value = {'success': True}
+        change_role.return_value = {'success': True}
+        set_trip.return_value = {'success': True}
+
+        yield {
+            'get_bot_user': get_user,
+            'get_or_create_bot_user': create_user,
+            'register_bot_user_as_driver': register_driver,
+            'update_bot_user_driver_status': update_status,
+            'change_bot_user_role': change_role,
+            'set_bot_user_active_trip': set_trip,
+        }
+
+
 # =============================================================================
 # Driver Registration Tests
 # =============================================================================
 
 
 @pytest.mark.asyncio
-async def test_process_driver_car_handler_service_unavailable(mock_update, mock_context):
+async def test_process_driver_car_handler_service_unavailable(mock_update, mock_context, mock_api_client):
     """Ensure the handler surface handles service unavailability."""
     chat_id = 12345
-    mock_response = {
+
+    # Configure APIClient to return service unavailable error
+    mock_api_client['register_bot_user_as_driver'].return_value = {
         'success': False,
-        'driver_id': None,
+        'data': None,
         'error': {
             'status_code': 503,
             'message': 'Сервіс недоступний. Спробуйте пізніше.'
-        },
-        'raw_response': None
+        }
     }
 
-    mock_register = AsyncMock(return_value=mock_response)
     helpers = {
         'safe_send': main.safe_send,
-        'register_driver_in_service': mock_register,
-        'update_driver_status': AsyncMock(),
+        'update_driver_status': AsyncMock(return_value={'success': True, 'error': None}),
         'fetch_driver_trips': AsyncMock(return_value={'success': True, 'trips': [], 'error': None}),
         'send_trip_response': AsyncMock(return_value={'success': True, 'error': None}),
         'finish_trip': AsyncMock(return_value={'success': True}),
@@ -104,8 +132,7 @@ async def test_process_driver_car_handler_service_unavailable(mock_update, mock_
 
     await driver.process_driver_car_handler(mock_update, mock_context)
 
-    mock_register.assert_called_once_with(chat_id, 'Test Driver', 'Toyota Camry')
-    assert chat_id not in main.user_roles
+    mock_api_client['register_bot_user_as_driver'].assert_awaited_once_with(chat_id, 'Test Driver', 'Toyota Camry')
 
     last_reply = mock_update.message.reply_text.call_args_list[-1][0][0]
     assert 'Помилка реєстрації' in last_reply
@@ -113,24 +140,23 @@ async def test_process_driver_car_handler_service_unavailable(mock_update, mock_
 
 
 @pytest.mark.asyncio
-async def test_process_driver_car_handler_timeout(mock_update, mock_context):
+async def test_process_driver_car_handler_timeout(mock_update, mock_context, mock_api_client):
     """Ensure the handler surface handles timeouts gracefully."""
     chat_id = 12345
-    mock_response = {
+
+    # Configure APIClient to return timeout error
+    mock_api_client['register_bot_user_as_driver'].return_value = {
         'success': False,
-        'driver_id': None,
+        'data': None,
         'error': {
             'status_code': 504,
             'message': 'Сервіс не відповідає. Спробуйте пізніше.'
-        },
-        'raw_response': None
+        }
     }
 
-    mock_register = AsyncMock(return_value=mock_response)
     helpers = {
         'safe_send': main.safe_send,
-        'register_driver_in_service': mock_register,
-        'update_driver_status': AsyncMock(),
+        'update_driver_status': AsyncMock(return_value={'success': True, 'error': None}),
         'fetch_driver_trips': AsyncMock(return_value={'success': True, 'trips': [], 'error': None}),
         'send_trip_response': AsyncMock(return_value={'success': True, 'error': None}),
         'finish_trip': AsyncMock(return_value={'success': True}),
@@ -154,8 +180,7 @@ async def test_process_driver_car_handler_timeout(mock_update, mock_context):
 
     await driver.process_driver_car_handler(mock_update, mock_context)
 
-    mock_register.assert_called_once_with(chat_id, 'Test Driver', 'Toyota Camry')
-    assert chat_id not in main.user_roles
+    mock_api_client['register_bot_user_as_driver'].assert_awaited_once_with(chat_id, 'Test Driver', 'Toyota Camry')
 
     last_reply = mock_update.message.reply_text.call_args_list[-1][0][0]
     assert 'Помилка реєстрації' in last_reply
@@ -245,24 +270,25 @@ def test_driver_menu_registered_online():
 
 
 @pytest.mark.asyncio
-async def test_driver_info_persistence(mock_update, mock_context):
-    """Test that driver info is properly stored in `main.user_roles` via handler."""
+async def test_driver_info_persistence(mock_update, mock_context, mock_api_client):
+    """Test that driver info is properly registered via API."""
     chat_id = 12345
 
-    # Prepare mocked helper that returns a successful registration
-    mock_register = AsyncMock()
-    mock_register.return_value = {
+    # Configure APIClient to return successful registration
+    mock_api_client['register_bot_user_as_driver'].return_value = {
         'success': True,
-        'driver_id': 'drv_123',
-        'error': None,
-        'raw_response': {'id': 'drv_123'}
+        'data': {
+            'driver_id': 'drv_123',
+            'current_role': 'driver',
+            'driver_status': 'offline'
+        },
+        'error': None
     }
 
     # Build helpers passed into register_handlers
     helpers = {
         'safe_send': main.safe_send,
-        'register_driver_in_service': mock_register,
-        'update_driver_status': AsyncMock(),
+        'update_driver_status': AsyncMock(return_value={'success': True, 'error': None}),
         'fetch_driver_trips': AsyncMock(return_value={'success': True, 'trips': [], 'error': None}),
         'send_trip_response': AsyncMock(return_value={'success': True, 'error': None}),
         'finish_trip': AsyncMock(return_value={'success': True}),
@@ -284,39 +310,33 @@ async def test_driver_info_persistence(mock_update, mock_context):
     # Invoke the process_driver_car handler directly
     await driver.process_driver_car_handler(mock_update, mock_context)
 
-    # Verify shared state was updated
-    assert chat_id in main.user_roles
-    entry = main.user_roles[chat_id]
-    assert entry['role'] == 'driver'
-    assert entry['registered'] is True
-    assert entry['driver_id'] == 'drv_123'
-    assert entry['status'] == 'offline'
-    mock_register.assert_called_once_with(chat_id, 'Test Driver', 'Toyota Camry')
+    # Verify API was called correctly
+    mock_api_client['register_bot_user_as_driver'].assert_awaited_once_with(chat_id, 'Test Driver', 'Toyota Camry')
 
 
 @pytest.mark.asyncio
-async def test_driver_status_update(mock_update, mock_context):
-    """Test that driver status is properly updated via handlers."""
+async def test_driver_status_update(mock_update, mock_context, mock_api_client):
+    """Test that driver status is properly updated via API."""
     chat_id = 12345
 
-    # Seed main.user_roles with a registered driver
-    main.user_roles[chat_id] = {
-        'role': 'driver',
-        'registered': True,
-        'driver_id': 'drv_123',
-        'name': 'Test Driver',
-        'car_description': 'Toyota Camry',
-        'status': 'offline'
+    # Configure APIClient to return registered driver
+    mock_api_client['get_bot_user'].return_value = {
+        'success': True,
+        'data': {
+            'current_role': 'driver',
+            'driver_id': 'drv_123',
+            'driver_name': 'Test Driver',
+            'car_description': 'Toyota Camry',
+            'driver_status': 'offline'
+        }
     }
 
-    # Prepare mocked update_driver_status helper
-    mock_update_status = AsyncMock()
-    mock_update_status.return_value = {'success': True, 'error': None}
+    # Configure status update to succeed
+    mock_api_client['update_bot_user_driver_status'].return_value = {'success': True}
 
     helpers = {
         'safe_send': main.safe_send,
-        'register_driver_in_service': AsyncMock(),
-        'update_driver_status': mock_update_status,
+        'update_driver_status': AsyncMock(return_value={'success': True, 'error': None}),
         'fetch_driver_trips': AsyncMock(return_value={'success': True, 'trips': [], 'error': None}),
         'send_trip_response': AsyncMock(return_value={'success': True, 'error': None}),
         'finish_trip': AsyncMock(return_value={'success': True}),
@@ -332,33 +352,44 @@ async def test_driver_status_update(mock_update, mock_context):
     driver.register_handlers(application, main.user_orders, main.user_roles, main.BUTTONS, main.KEYBOARDS, helpers, DEBUGGING=False)
 
     await driver.go_online_handler(mock_update, mock_context)
-    assert main.user_roles[chat_id]['status'] == 'online'
-    mock_update_status.assert_called_once_with('drv_123', 'online')
+    mock_api_client['update_bot_user_driver_status'].assert_awaited_with(chat_id, is_online=True)
 
-    # Now mock going offline
-    mock_update_status.reset_mock()
-    mock_update_status.return_value = {'success': True, 'error': None}
+    # Now test going offline - update mock to return online status first
+    mock_api_client['update_bot_user_driver_status'].reset_mock()
+    mock_api_client['get_bot_user'].return_value = {
+        'success': True,
+        'data': {
+            'current_role': 'driver',
+            'driver_id': 'drv_123',
+            'driver_name': 'Test Driver',
+            'car_description': 'Toyota Camry',
+            'driver_status': 'online'  # Changed to online
+        }
+    }
 
     await driver.go_offline_handler(mock_update, mock_context)
-    assert main.user_roles[chat_id]['status'] == 'offline'
-    mock_update_status.assert_called_once_with('drv_123', 'offline')
+    mock_api_client['update_bot_user_driver_status'].assert_awaited_with(chat_id, is_online=False)
 
 
 @pytest.mark.asyncio
-async def test_go_online_handler_service_unavailable(mock_update, mock_context):
-    """Handler keeps driver offline when the service cannot be reached."""
+async def test_go_online_handler_service_unavailable(mock_update, mock_context, mock_api_client):
+    """Handler shows error when the service cannot be reached."""
     chat_id = 12345
-    main.user_roles[chat_id] = {
-        'role': 'driver',
-        'registered': True,
-        'driver_id': 'drv_123',
-        'name': 'Test Driver',
-        'car_description': 'Toyota Camry',
-        'status': 'offline'
+
+    # Configure APIClient to return registered driver
+    mock_api_client['get_bot_user'].return_value = {
+        'success': True,
+        'data': {
+            'current_role': 'driver',
+            'driver_id': 'drv_123',
+            'driver_name': 'Test Driver',
+            'car_description': 'Toyota Camry',
+            'driver_status': 'offline'
+        }
     }
 
-    mock_update_status = AsyncMock()
-    mock_update_status.return_value = {
+    # Configure status update to fail
+    mock_api_client['update_bot_user_driver_status'].return_value = {
         'success': False,
         'error': {
             'status_code': 503,
@@ -368,8 +399,7 @@ async def test_go_online_handler_service_unavailable(mock_update, mock_context):
 
     helpers = {
         'safe_send': main.safe_send,
-        'register_driver_in_service': AsyncMock(),
-        'update_driver_status': mock_update_status,
+        'update_driver_status': AsyncMock(return_value={'success': True, 'error': None}),
         'fetch_driver_trips': AsyncMock(return_value={'success': True, 'trips': [], 'error': None}),
         'send_trip_response': AsyncMock(return_value={'success': True, 'error': None}),
         'finish_trip': AsyncMock(return_value={'success': True}),
@@ -383,8 +413,7 @@ async def test_go_online_handler_service_unavailable(mock_update, mock_context):
     driver.register_handlers(application, main.user_orders, main.user_roles, main.BUTTONS, main.KEYBOARDS, helpers, DEBUGGING=False)
 
     await driver.go_online_handler(mock_update, mock_context)
-    assert main.user_roles[chat_id]['status'] == 'offline'
-    mock_update_status.assert_called_once_with('drv_123', 'online')
+    mock_api_client['update_bot_user_driver_status'].assert_awaited_once_with(chat_id, is_online=True)
 
     last_reply = mock_update.message.reply_text.call_args_list[-1][0][0]
     assert 'Помилка' in last_reply
@@ -396,27 +425,20 @@ async def test_go_online_handler_service_unavailable(mock_update, mock_context):
 # =============================================================================
 
 
-def _build_driver_helpers(register_return=None):
-    register_mock = AsyncMock(return_value=register_return or {
-        'success': True,
-        'driver_id': 'drv_test',
-        'error': None,
-        'raw_response': {'id': 'drv_test'}
-    })
+def _build_driver_helpers():
     return {
         'safe_send': main.safe_send,
-        'register_driver_in_service': register_mock,
-        'update_driver_status': AsyncMock(),
+        'update_driver_status': AsyncMock(return_value={'success': True, 'error': None}),
         'fetch_driver_trips': AsyncMock(return_value={'success': True, 'trips': [], 'error': None}),
         'send_trip_response': AsyncMock(return_value={'success': True, 'error': None}),
         'finish_trip': AsyncMock(return_value={'success': True}),
-    }, register_mock
+    }
 
 
 @pytest.mark.asyncio
-async def test_driver_name_validation_too_short(mock_update, mock_context):
+async def test_driver_name_validation_too_short(mock_update, mock_context, mock_api_client):
     """Handler returns DRIVER_NAME when the supplied name is too short."""
-    helpers, register_mock = _build_driver_helpers()
+    helpers = _build_driver_helpers()
     application = MagicMock()
     driver.register_handlers(
         application,
@@ -436,13 +458,13 @@ async def test_driver_name_validation_too_short(mock_update, mock_context):
     assert result == driver.DRIVER_NAME
     last_reply = mock_update.message.reply_text.call_args[0][0]
     assert "занадто коротке" in last_reply
-    register_mock.assert_not_awaited()
+    mock_api_client['register_bot_user_as_driver'].assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_driver_name_validation_accepts_valid_name(mock_update, mock_context):
+async def test_driver_name_validation_accepts_valid_name(mock_update, mock_context, mock_api_client):
     """Handler proceeds to car step when the name is valid."""
-    helpers, register_mock = _build_driver_helpers()
+    helpers = _build_driver_helpers()
     application = MagicMock()
     driver.register_handlers(
         application,
@@ -463,13 +485,13 @@ async def test_driver_name_validation_accepts_valid_name(mock_update, mock_conte
     assert mock_context.user_data['driver_name'] == "John Doe"
     last_reply = mock_update.message.reply_text.call_args_list[-1][0][0]
     assert "Опишіть ваше авто" in last_reply
-    register_mock.assert_not_awaited()
+    mock_api_client['register_bot_user_as_driver'].assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_driver_car_validation_too_short(mock_update, mock_context):
+async def test_driver_car_validation_too_short(mock_update, mock_context, mock_api_client):
     """Handler keeps asking for car description when the text is too short."""
-    helpers, register_mock = _build_driver_helpers()
+    helpers = _build_driver_helpers()
     application = MagicMock()
     driver.register_handlers(
         application,
@@ -490,26 +512,24 @@ async def test_driver_car_validation_too_short(mock_update, mock_context):
     assert result == driver.DRIVER_CAR
     last_reply = mock_update.message.reply_text.call_args[0][0]
     assert "Опис авто занадто короткий" in last_reply
-    register_mock.assert_not_awaited()
+    mock_api_client['register_bot_user_as_driver'].assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_driver_car_validation_accepts_valid_description(mock_update, mock_context):
+async def test_driver_car_validation_accepts_valid_description(mock_update, mock_context, mock_api_client):
     """Handler registers the driver after receiving a valid car description."""
-    register_mock = AsyncMock(return_value={
+    # Configure API to return successful registration
+    mock_api_client['register_bot_user_as_driver'].return_value = {
         'success': True,
-        'driver_id': 'drv_123',
-        'error': None,
-        'raw_response': {'id': 'drv_123'}
-    })
-    helpers = {
-        'safe_send': main.safe_send,
-        'register_driver_in_service': register_mock,
-        'update_driver_status': AsyncMock(),
-        'fetch_driver_trips': AsyncMock(return_value={'success': True, 'trips': [], 'error': None}),
-        'send_trip_response': AsyncMock(return_value={'success': True, 'error': None}),
-        'finish_trip': AsyncMock(return_value={'success': True}),
+        'data': {
+            'driver_id': 'drv_123',
+            'current_role': 'driver',
+            'driver_status': 'offline'
+        },
+        'error': None
     }
+
+    helpers = _build_driver_helpers()
     application = MagicMock()
     driver.register_handlers(
         application,
@@ -529,9 +549,7 @@ async def test_driver_car_validation_accepts_valid_description(mock_update, mock
     result = await driver.process_driver_car_handler(mock_update, mock_context)
 
     assert result == driver.ConversationHandler.END
-    register_mock.assert_awaited_once_with(chat_id, "Test Driver", "Toyota Camry")
-    role_entry = main.user_roles.get(chat_id)
-    assert role_entry and role_entry['registered'] is True
+    mock_api_client['register_bot_user_as_driver'].assert_awaited_once_with(chat_id, "Test Driver", "Toyota Camry")
     last_reply = mock_update.message.reply_text.call_args_list[-1][0][0]
     assert "Реєстрацію завершено" in last_reply
 
@@ -563,11 +581,17 @@ def _build_trip_helpers(fetch_trips_response=None, trip_response_result=None):
 
 
 @pytest.mark.asyncio
-async def test_show_driver_orders_unregistered(mock_update, mock_context):
+async def test_show_driver_orders_unregistered(mock_update, mock_context, mock_api_client):
     """Test that unregistered drivers cannot see orders."""
+    # Configure API to return no user data
+    mock_api_client['get_bot_user'].return_value = {
+        'success': False,
+        'data': None
+    }
+
     helpers, fetch_mock, _ = _build_trip_helpers()
     application = MagicMock()
-    
+
     driver.register_handlers(
         application,
         main.user_orders,
@@ -577,30 +601,33 @@ async def test_show_driver_orders_unregistered(mock_update, mock_context):
         helpers,
         DEBUGGING=False
     )
-    
+
     mock_update.message = mock_update.effective_message
-    
+
     await driver.show_driver_orders_handler(mock_update, mock_context)
-    
+
     last_reply = mock_update.message.reply_text.call_args_list[-1][0][0]
     assert 'зареєструйтесь як водій' in last_reply
     fetch_mock.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_show_driver_orders_offline(mock_update, mock_context):
+async def test_show_driver_orders_offline(mock_update, mock_context, mock_api_client):
     """Test that offline drivers get a message to go online first."""
+    # Configure API to return offline driver
+    mock_api_client['get_bot_user'].return_value = {
+        'success': True,
+        'data': {
+            'current_role': 'driver',
+            'driver_id': 'drv_123',
+            'driver_status': 'offline',
+            'active_trip_id': None
+        }
+    }
+
     helpers, fetch_mock, _ = _build_trip_helpers()
     application = MagicMock()
-    
-    chat_id = mock_update.effective_chat.id
-    main.user_roles[chat_id] = {
-        'role': 'driver',
-        'registered': True,
-        'driver_id': 'drv_123',
-        'status': 'offline'
-    }
-    
+
     driver.register_handlers(
         application,
         main.user_orders,
@@ -610,34 +637,37 @@ async def test_show_driver_orders_offline(mock_update, mock_context):
         helpers,
         DEBUGGING=False
     )
-    
+
     mock_update.message = mock_update.effective_message
-    
+
     await driver.show_driver_orders_handler(mock_update, mock_context)
-    
+
     last_reply = mock_update.message.reply_text.call_args_list[-1][0][0]
     assert 'офлайн' in last_reply.lower()
     fetch_mock.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_show_driver_orders_no_trips(mock_update, mock_context):
+async def test_show_driver_orders_no_trips(mock_update, mock_context, mock_api_client):
     """Test showing empty trips list for online driver."""
+    # Configure API to return online driver
+    mock_api_client['get_bot_user'].return_value = {
+        'success': True,
+        'data': {
+            'current_role': 'driver',
+            'driver_id': 'drv_123',
+            'driver_status': 'online',
+            'active_trip_id': None
+        }
+    }
+
     helpers, fetch_mock, _ = _build_trip_helpers({
         'success': True,
         'trips': [],
         'error': None,
     })
     application = MagicMock()
-    
-    chat_id = mock_update.effective_chat.id
-    main.user_roles[chat_id] = {
-        'role': 'driver',
-        'registered': True,
-        'driver_id': 'drv_123',
-        'status': 'online'
-    }
-    
+
     driver.register_handlers(
         application,
         main.user_orders,
@@ -647,22 +677,33 @@ async def test_show_driver_orders_no_trips(mock_update, mock_context):
         helpers,
         DEBUGGING=False
     )
-    
+
     mock_update.message = mock_update.effective_message
-    
+
     await driver.show_driver_orders_handler(mock_update, mock_context)
-    
+
     fetch_mock.assert_awaited_once_with('drv_123')
     last_reply = mock_update.message.reply_text.call_args_list[-1][0][0]
     assert 'немає нових замовлень' in last_reply
 
 
 @pytest.mark.asyncio
-async def test_show_driver_orders_with_trips(mock_update, mock_context):
+async def test_show_driver_orders_with_trips(mock_update, mock_context, mock_api_client):
     """Test showing pending trips for online driver."""
+    # Configure API to return online driver
+    mock_api_client['get_bot_user'].return_value = {
+        'success': True,
+        'data': {
+            'current_role': 'driver',
+            'driver_id': 'drv_123',
+            'driver_status': 'online',
+            'active_trip_id': None
+        }
+    }
+
     trips = [
-        {'id': 'trip_001', 'pickup': 'вул. Хрещатик, 1', 'dropoff': 'пл. Незалежності', 'comment': 'Швидко'},
-        {'id': 'trip_002', 'pickup': 'Центральний вокзал', 'dropoff': 'Аеропорт', 'comment': ''}
+        {'id': 'trip_001', 'status': 'PENDING', 'pickup': 'вул. Хрещатик, 1', 'dropoff': 'пл. Незалежності', 'comment': 'Швидко'},
+        {'id': 'trip_002', 'status': 'PENDING', 'pickup': 'Центральний вокзал', 'dropoff': 'Аеропорт', 'comment': ''}
     ]
     helpers, fetch_mock, _ = _build_trip_helpers({
         'success': True,
@@ -670,15 +711,7 @@ async def test_show_driver_orders_with_trips(mock_update, mock_context):
         'error': None,
     })
     application = MagicMock()
-    
-    chat_id = mock_update.effective_chat.id
-    main.user_roles[chat_id] = {
-        'role': 'driver',
-        'registered': True,
-        'driver_id': 'drv_123',
-        'status': 'online'
-    }
-    
+
     driver.register_handlers(
         application,
         main.user_orders,
@@ -688,18 +721,18 @@ async def test_show_driver_orders_with_trips(mock_update, mock_context):
         helpers,
         DEBUGGING=False
     )
-    
+
     mock_update.message = mock_update.effective_message
-    
+
     await driver.show_driver_orders_handler(mock_update, mock_context)
-    
+
     fetch_mock.assert_awaited_once_with('drv_123')
-    
+
     # Should have called reply_text multiple times (loading + trips + summary)
     reply_calls = mock_update.message.reply_text.call_args_list
     # At least: loading message, 2 trips, summary
     assert len(reply_calls) >= 4
-    
+
     # Check that trip info is displayed (underscores may be escaped for Markdown)
     all_replies = ' '.join([call[0][0] for call in reply_calls])
     # trip_001 becomes trip\_001 in Markdown, so check for either
@@ -710,23 +743,26 @@ async def test_show_driver_orders_with_trips(mock_update, mock_context):
 
 
 @pytest.mark.asyncio
-async def test_show_driver_orders_service_error(mock_update, mock_context):
+async def test_show_driver_orders_service_error(mock_update, mock_context, mock_api_client):
     """Test error handling when trip service is unavailable."""
+    # Configure API to return online driver
+    mock_api_client['get_bot_user'].return_value = {
+        'success': True,
+        'data': {
+            'current_role': 'driver',
+            'driver_id': 'drv_123',
+            'driver_status': 'online',
+            'active_trip_id': None
+        }
+    }
+
     helpers, fetch_mock, _ = _build_trip_helpers({
         'success': False,
         'trips': [],
         'error': {'status_code': 503, 'message': 'Сервіс недоступний. Спробуйте пізніше.'},
     })
     application = MagicMock()
-    
-    chat_id = mock_update.effective_chat.id
-    main.user_roles[chat_id] = {
-        'role': 'driver',
-        'registered': True,
-        'driver_id': 'drv_123',
-        'status': 'online'
-    }
-    
+
     driver.register_handlers(
         application,
         main.user_orders,
@@ -736,11 +772,11 @@ async def test_show_driver_orders_service_error(mock_update, mock_context):
         helpers,
         DEBUGGING=False
     )
-    
+
     mock_update.message = mock_update.effective_message
-    
+
     await driver.show_driver_orders_handler(mock_update, mock_context)
-    
+
     fetch_mock.assert_awaited_once_with('drv_123')
     last_reply = mock_update.message.reply_text.call_args_list[-1][0][0]
     assert 'Помилка отримання замовлень' in last_reply
@@ -748,25 +784,30 @@ async def test_show_driver_orders_service_error(mock_update, mock_context):
 
 
 @pytest.mark.asyncio
-async def test_accept_trip_success(mock_update, mock_context, mock_callback_query):
+async def test_accept_trip_success(mock_update, mock_context, mock_callback_query, mock_api_client):
     """Test successful trip acceptance."""
+    chat_id = 12345
+
+    # Configure API to return online driver
+    mock_api_client['get_bot_user'].return_value = {
+        'success': True,
+        'data': {
+            'current_role': 'driver',
+            'driver_id': 'drv_123',
+            'driver_status': 'online',
+            'active_trip_id': None
+        }
+    }
+
     helpers, _, send_mock = _build_trip_helpers(
         trip_response_result={'success': True, 'error': None}
     )
     application = MagicMock()
-    
-    chat_id = 12345
+
     mock_callback_query.data = 'accept_trip_trip_001'
     mock_callback_query.message.chat.id = chat_id
     mock_update.callback_query = mock_callback_query
-    
-    main.user_roles[chat_id] = {
-        'role': 'driver',
-        'registered': True,
-        'driver_id': 'drv_123',
-        'status': 'online'
-    }
-    
+
     driver.register_handlers(
         application,
         main.user_orders,
@@ -776,20 +817,33 @@ async def test_accept_trip_success(mock_update, mock_context, mock_callback_quer
         helpers,
         DEBUGGING=False
     )
-    
+
     await driver.accept_trip_handler(mock_update, mock_context)
-    
+
     mock_callback_query.answer.assert_awaited_once()
     send_mock.assert_awaited_once_with('drv_123', 'trip_001', 'accept')
-    
+
     # Check final message contains success
     last_edit = mock_callback_query.edit_message_text.call_args_list[-1]
     assert 'прийнято' in last_edit[1]['text'].lower()
 
 
 @pytest.mark.asyncio
-async def test_accept_trip_expired(mock_update, mock_context, mock_callback_query):
+async def test_accept_trip_expired(mock_update, mock_context, mock_callback_query, mock_api_client):
     """Test accepting an expired trip."""
+    chat_id = 12345
+
+    # Configure API to return online driver
+    mock_api_client['get_bot_user'].return_value = {
+        'success': True,
+        'data': {
+            'current_role': 'driver',
+            'driver_id': 'drv_123',
+            'driver_status': 'online',
+            'active_trip_id': None
+        }
+    }
+
     helpers, _, send_mock = _build_trip_helpers(
         trip_response_result={
             'success': False,
@@ -797,19 +851,11 @@ async def test_accept_trip_expired(mock_update, mock_context, mock_callback_quer
         }
     )
     application = MagicMock()
-    
-    chat_id = 12345
+
     mock_callback_query.data = 'accept_trip_trip_001'
     mock_callback_query.message.chat.id = chat_id
     mock_update.callback_query = mock_callback_query
-    
-    main.user_roles[chat_id] = {
-        'role': 'driver',
-        'registered': True,
-        'driver_id': 'drv_123',
-        'status': 'online'
-    }
-    
+
     driver.register_handlers(
         application,
         main.user_orders,
@@ -819,35 +865,40 @@ async def test_accept_trip_expired(mock_update, mock_context, mock_callback_quer
         helpers,
         DEBUGGING=False
     )
-    
+
     await driver.accept_trip_handler(mock_update, mock_context)
-    
+
     send_mock.assert_awaited_once_with('drv_123', 'trip_001', 'accept')
-    
+
     last_edit = mock_callback_query.edit_message_text.call_args_list[-1]
     assert 'недоступне' in last_edit[1]['text'].lower()
 
 
 @pytest.mark.asyncio
-async def test_decline_trip_success(mock_update, mock_context, mock_callback_query):
+async def test_decline_trip_success(mock_update, mock_context, mock_callback_query, mock_api_client):
     """Test successful trip rejection."""
+    chat_id = 12345
+
+    # Configure API to return online driver
+    mock_api_client['get_bot_user'].return_value = {
+        'success': True,
+        'data': {
+            'current_role': 'driver',
+            'driver_id': 'drv_123',
+            'driver_status': 'online',
+            'active_trip_id': None
+        }
+    }
+
     helpers, _, send_mock = _build_trip_helpers(
         trip_response_result={'success': True, 'error': None}
     )
     application = MagicMock()
-    
-    chat_id = 12345
+
     mock_callback_query.data = 'decline_trip_trip_001'
     mock_callback_query.message.chat.id = chat_id
     mock_update.callback_query = mock_callback_query
-    
-    main.user_roles[chat_id] = {
-        'role': 'driver',
-        'registered': True,
-        'driver_id': 'drv_123',
-        'status': 'online'
-    }
-    
+
     driver.register_handlers(
         application,
         main.user_orders,
@@ -857,19 +908,32 @@ async def test_decline_trip_success(mock_update, mock_context, mock_callback_que
         helpers,
         DEBUGGING=False
     )
-    
+
     await driver.decline_trip_handler(mock_update, mock_context)
-    
+
     mock_callback_query.answer.assert_awaited_once()
     send_mock.assert_awaited_once_with('drv_123', 'trip_001', 'reject')
-    
+
     last_edit = mock_callback_query.edit_message_text.call_args_list[-1]
     assert 'відхилено' in last_edit[1]['text'].lower()
 
 
 @pytest.mark.asyncio
-async def test_decline_trip_service_unavailable(mock_update, mock_context, mock_callback_query):
+async def test_decline_trip_service_unavailable(mock_update, mock_context, mock_callback_query, mock_api_client):
     """Test rejecting trip when service is unavailable."""
+    chat_id = 12345
+
+    # Configure API to return online driver
+    mock_api_client['get_bot_user'].return_value = {
+        'success': True,
+        'data': {
+            'current_role': 'driver',
+            'driver_id': 'drv_123',
+            'driver_status': 'online',
+            'active_trip_id': None
+        }
+    }
+
     helpers, _, send_mock = _build_trip_helpers(
         trip_response_result={
             'success': False,
@@ -877,19 +941,11 @@ async def test_decline_trip_service_unavailable(mock_update, mock_context, mock_
         }
     )
     application = MagicMock()
-    
-    chat_id = 12345
+
     mock_callback_query.data = 'decline_trip_trip_001'
     mock_callback_query.message.chat.id = chat_id
     mock_update.callback_query = mock_callback_query
-    
-    main.user_roles[chat_id] = {
-        'role': 'driver',
-        'registered': True,
-        'driver_id': 'drv_123',
-        'status': 'online'
-    }
-    
+
     driver.register_handlers(
         application,
         main.user_orders,
@@ -899,29 +955,33 @@ async def test_decline_trip_service_unavailable(mock_update, mock_context, mock_
         helpers,
         DEBUGGING=False
     )
-    
+
     await driver.decline_trip_handler(mock_update, mock_context)
-    
+
     send_mock.assert_awaited_once_with('drv_123', 'trip_001', 'reject')
-    
+
     last_edit = mock_callback_query.edit_message_text.call_args_list[-1]
     assert 'помилка' in last_edit[1]['text'].lower()
 
 
 @pytest.mark.asyncio
-async def test_accept_trip_unregistered_driver(mock_update, mock_context, mock_callback_query):
+async def test_accept_trip_unregistered_driver(mock_update, mock_context, mock_callback_query, mock_api_client):
     """Test that unregistered drivers cannot accept trips."""
+    chat_id = 12345
+
+    # Configure API to return no user
+    mock_api_client['get_bot_user'].return_value = {
+        'success': False,
+        'data': None
+    }
+
     helpers, _, send_mock = _build_trip_helpers()
     application = MagicMock()
-    
-    chat_id = 12345
+
     mock_callback_query.data = 'accept_trip_trip_001'
     mock_callback_query.message.chat.id = chat_id
     mock_update.callback_query = mock_callback_query
-    
-    # No driver registered
-    main.user_roles.clear()
-    
+
     driver.register_handlers(
         application,
         main.user_orders,
@@ -931,9 +991,9 @@ async def test_accept_trip_unregistered_driver(mock_update, mock_context, mock_c
         helpers,
         DEBUGGING=False
     )
-    
+
     await driver.accept_trip_handler(mock_update, mock_context)
-    
+
     send_mock.assert_not_awaited()
     last_edit = mock_callback_query.edit_message_text.call_args_list[-1]
     assert 'не зареєстровані' in last_edit[1]['text'].lower()

--- a/driver-service/Dockerfile.migrations
+++ b/driver-service/Dockerfile.migrations
@@ -6,7 +6,7 @@ WORKDIR /app
 # Versions matched with driver-service/requirements.txt where applicable
 RUN pip install --no-cache-dir \
     alembic==1.13.1 \
-    psycopg2-binary==2.9.9 \
+    psycopg2-binary==2.9.10 \
     sqlalchemy==2.0.35 \
     python-dotenv==1.0.1
 

--- a/driver-service/alembic/versions/a3d8f9b2c1e5_add_bot_users_table.py
+++ b/driver-service/alembic/versions/a3d8f9b2c1e5_add_bot_users_table.py
@@ -1,0 +1,45 @@
+"""Add bot_users table
+
+Revision ID: a3d8f9b2c1e5
+Revises: 42f496ca8ae8
+Create Date: 2026-01-22 19:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a3d8f9b2c1e5'
+down_revision: Union[str, Sequence[str], None] = '42f496ca8ae8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema - create bot_users table."""
+    op.create_table('bot_users',
+        sa.Column('telegram_chat_id', sa.BigInteger(), nullable=False),
+        sa.Column('current_role', sa.String(length=20), nullable=False, server_default='passenger'),
+        sa.Column('driver_id', postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column('driver_name', sa.String(length=100), nullable=True),
+        sa.Column('car_description', sa.String(length=200), nullable=True),
+        sa.Column('driver_status', sa.String(length=20), nullable=False, server_default='offline'),
+        sa.Column('active_trip_id', sa.String(length=100), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.PrimaryKeyConstraint('telegram_chat_id'),
+        sa.ForeignKeyConstraint(['driver_id'], ['drivers.id'], ondelete='SET NULL')
+    )
+
+    # Create index on driver_id for faster lookups
+    op.create_index(op.f('ix_bot_users_driver_id'), 'bot_users', ['driver_id'], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema - drop bot_users table."""
+    op.drop_index(op.f('ix_bot_users_driver_id'), table_name='bot_users')
+    op.drop_table('bot_users')

--- a/driver-service/src/driver_models.py
+++ b/driver-service/src/driver_models.py
@@ -1,7 +1,10 @@
-from sqlalchemy import String, Boolean
+from sqlalchemy import String, Boolean, BigInteger, DateTime, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+from sqlalchemy.sql import func
+from typing import Optional
 import uuid
+from datetime import datetime
 
 # Це основний клас, який Alembic шукає в env.py
 class Base(DeclarativeBase):
@@ -19,4 +22,41 @@ class Driver(Base):
 
     def __repr__(self) -> str:
         return f"Driver(id={self.id!r}, name={self.first_name!r})"
+
+# Опис таблиці bot_users - зберігає стан користувачів Telegram бота
+class BotUser(Base):
+    __tablename__ = "bot_users"
+
+    # Telegram chat_id як primary key (може бути дуже великим числом)
+    telegram_chat_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+
+    # Поточна активна роль користувача ('driver' або 'passenger')
+    current_role: Mapped[str] = mapped_column(String(20), nullable=False, default='passenger')
+
+    # Зовнішній ключ до таблиці drivers (nullable, якщо користувач не зареєстрований як водій)
+    driver_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey('drivers.id', ondelete='SET NULL'),
+        nullable=True
+    )
+
+    # Дані водія для відображення (копіюються з Driver при реєстрації)
+    driver_name: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+    car_description: Mapped[Optional[str]] = mapped_column(String(200), nullable=True)
+
+    # Статус водія ('online', 'offline')
+    driver_status: Mapped[str] = mapped_column(String(20), nullable=False, default='offline')
+
+    # ID активної поїздки (якщо водій на поїздці)
+    active_trip_id: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+
+    # Timestamps
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    # Relationship до Driver (опціонально, для зручності)
+    driver: Mapped[Optional["Driver"]] = relationship("Driver", foreign_keys=[driver_id])
+
+    def __repr__(self) -> str:
+        return f"BotUser(chat_id={self.telegram_chat_id!r}, role={self.current_role!r}, driver_id={self.driver_id!r})"
     

--- a/driver-service/src/main.py
+++ b/driver-service/src/main.py
@@ -2,13 +2,23 @@ import asyncio
 import logging
 from contextlib import asynccontextmanager
 from uuid import UUID
-from fastapi import FastAPI, HTTPException, status, Depends
+from typing import Optional
+from fastapi import FastAPI, HTTPException, status, Depends, Response
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import update
 
 # Імпорти модулів проекту
 from src.database import get_db
+from src.driver_models import Driver, BotUser
 from src.services.driver_repository import DriverRepository
+from src.services.bot_user_repository import BotUserRepository
 from src.schemas.driver_schemas import DriverCreate, DriverResponse
+from src.schemas.bot_user_schemas import (
+    BotUserCreate,
+    BotUserUpdate,
+    BotUserResponse,
+    BotUserDriverRegistration
+)
 from src.config import settings
 
 # Імпорти для Task #41
@@ -264,6 +274,231 @@ async def update_driver_status(driver_id: UUID, is_active: bool, db: AsyncSessio
 
     return updated
 
+# ========== BOT USERS MANAGEMENT ==========
+
+@app.post("/api/bot-users", response_model=BotUserResponse, tags=["Bot Users"])
+async def create_or_get_bot_user(
+    user_data: BotUserCreate,
+    response: Response,
+    db: AsyncSession = Depends(get_db)
+):
+    """
+    Get or create bot user by telegram_chat_id.
+    Used when user first interacts with the bot.
+    Returns HTTP 201 if created, HTTP 200 if retrieved existing.
+    """
+    repo = BotUserRepository(db)
+    bot_user, created = await repo.get_or_create(
+        chat_id=user_data.telegram_chat_id,
+        defaults={'current_role': user_data.current_role}
+    )
+
+    # Set appropriate status code based on whether user was created or retrieved
+    if created:
+        response.status_code = status.HTTP_201_CREATED
+        logger.info(f"Created new bot user: chat_id={bot_user.telegram_chat_id}")
+    else:
+        response.status_code = status.HTTP_200_OK
+        logger.info(f"Retrieved existing bot user: chat_id={bot_user.telegram_chat_id}")
+
+    return bot_user
+
+
+@app.get("/api/bot-users/{chat_id}", response_model=BotUserResponse, tags=["Bot Users"])
+async def get_bot_user(chat_id: int, db: AsyncSession = Depends(get_db)):
+    """Get bot user profile by telegram chat ID"""
+    repo = BotUserRepository(db)
+    bot_user = await repo.get_by_chat_id(chat_id)
+    if not bot_user:
+        raise HTTPException(status_code=404, detail="Bot user not found")
+    return bot_user
+
+
+@app.patch("/api/bot-users/{chat_id}", response_model=BotUserResponse, tags=["Bot Users"])
+async def update_bot_user(chat_id: int, updates: BotUserUpdate, db: AsyncSession = Depends(get_db)):
+    """Update bot user fields"""
+    repo = BotUserRepository(db)
+
+    # Filter out None values
+    update_data = {k: v for k, v in updates.model_dump().items() if v is not None}
+
+    if not update_data:
+        raise HTTPException(status_code=400, detail="No fields to update")
+
+    bot_user = await repo.update(chat_id, **update_data)
+    if not bot_user:
+        raise HTTPException(status_code=404, detail="Bot user not found")
+
+    return bot_user
+
+
+@app.post("/api/bot-users/register-driver", response_model=BotUserResponse, tags=["Bot Users"])
+async def register_bot_user_as_driver(
+    registration: BotUserDriverRegistration,
+    db: AsyncSession = Depends(get_db)
+):
+    """
+    Register bot user as driver.
+    Creates Driver record and updates BotUser with driver info.
+    All operations are performed within a single database transaction to ensure atomicity.
+    """
+    bot_user_repo = BotUserRepository(db)
+    driver_repo = DriverRepository(db)
+
+    # Get or create bot user (this has its own transaction handling)
+    bot_user, created = await bot_user_repo.get_or_create(registration.telegram_chat_id)
+
+    # Check if already registered as driver
+    if bot_user.driver_id:
+        logger.info(f"Bot user {registration.telegram_chat_id} already registered as driver")
+        return bot_user
+
+    # Split name into first_name and last_name
+    name_parts = registration.driver_name.strip().split(maxsplit=1)
+    first_name = name_parts[0] if name_parts else "Driver"
+    last_name = name_parts[1] if len(name_parts) > 1 else str(registration.telegram_chat_id)
+
+    # Generate safe phone number from telegram_chat_id
+    # Use last 10 digits to avoid exceeding phone number length limits
+    chat_id_str = str(registration.telegram_chat_id)
+    phone_suffix = chat_id_str[-10:] if len(chat_id_str) >= 10 else chat_id_str.zfill(10)
+    phone_number = f"+{phone_suffix}"
+
+    # Check if driver with this phone already exists (outside transaction)
+    existing_driver = await driver_repo.get_by_phone_number(phone_number)
+
+    # Perform driver creation and bot user update in a single transaction
+    # Using manual transaction control to ensure atomicity
+    try:
+        if existing_driver:
+            driver = existing_driver
+            driver_id = driver.id
+            logger.info(f"Found existing driver for phone {phone_number}: {driver_id}")
+        else:
+            # Create Driver record without auto-commit
+            driver = Driver(
+                first_name=first_name,
+                last_name=last_name,
+                phone_number=phone_number,
+                is_active=True
+            )
+            db.add(driver)
+            await db.flush()  # Flush to get driver.id without committing
+            driver_id = driver.id
+            logger.info(f"Created new driver: {driver_id}")
+
+        # Update BotUser directly without using repository method (to avoid auto-commit)
+        stmt = (
+            update(BotUser)
+            .where(BotUser.telegram_chat_id == registration.telegram_chat_id)
+            .values(
+                driver_id=driver_id,
+                driver_name=registration.driver_name,
+                car_description=registration.car_description,
+                current_role='driver'
+            )
+            .returning(BotUser)
+        )
+        result = await db.execute(stmt)
+        bot_user = result.scalar_one_or_none()
+
+        if not bot_user:
+            raise HTTPException(status_code=404, detail="Failed to update bot user with driver info")
+
+        # Commit the transaction (both driver create and bot user update)
+        await db.commit()
+        await db.refresh(bot_user)
+
+        # Transaction succeeded, now sync with in-memory storage
+        drivers_storage = app.state.drivers_storage
+        drivers_storage[str(driver_id)] = {
+            "id": str(driver_id),
+            "name": registration.driver_name,
+            "status": "OFFLINE",  # Start as offline
+            "latitude": 50.4501,
+            "longitude": 30.5234
+        }
+
+        logger.info(f"Bot user {registration.telegram_chat_id} registered as driver {driver_id}")
+        return bot_user
+
+    except HTTPException:
+        await db.rollback()
+        raise
+    except Exception as e:
+        await db.rollback()
+        logger.error(f"Failed to register bot user as driver: chat_id={registration.telegram_chat_id} error={str(e)}")
+        raise HTTPException(status_code=500, detail=f"Driver registration failed: {str(e)}")
+
+
+@app.patch("/api/bot-users/{chat_id}/role", response_model=BotUserResponse, tags=["Bot Users"])
+async def change_bot_user_role(chat_id: int, role: str, db: AsyncSession = Depends(get_db)):
+    """
+    Change user's current role (driver/passenger).
+    Preserves all data - user can switch between roles freely.
+    """
+    if role not in ['driver', 'passenger']:
+        raise HTTPException(status_code=400, detail="Role must be 'driver' or 'passenger'")
+
+    repo = BotUserRepository(db)
+    bot_user = await repo.update_role(chat_id, role)
+
+    if not bot_user:
+        raise HTTPException(status_code=404, detail="Bot user not found")
+
+    logger.info(f"Bot user {chat_id} changed role to {role}")
+    return bot_user
+
+
+@app.patch("/api/bot-users/{chat_id}/driver-status", response_model=BotUserResponse, tags=["Bot Users"])
+async def update_bot_user_driver_status(
+    chat_id: int,
+    is_online: bool,
+    db: AsyncSession = Depends(get_db)
+):
+    """Update driver's online/offline status"""
+    repo = BotUserRepository(db)
+    bot_user = await repo.get_by_chat_id(chat_id)
+
+    if not bot_user or not bot_user.driver_id:
+        raise HTTPException(status_code=404, detail="Bot user not registered as driver")
+
+    new_status = 'online' if is_online else 'offline'
+    bot_user = await repo.update_driver_status(chat_id, new_status)
+
+    # Sync with in-memory storage
+    drivers_storage = app.state.drivers_storage
+    driver_key = str(bot_user.driver_id)
+    if driver_key in drivers_storage:
+        drivers_storage[driver_key]["status"] = "ONLINE" if is_online else "OFFLINE"
+
+    logger.info(f"Bot user {chat_id} driver status changed to {new_status}")
+    return bot_user
+
+
+@app.patch("/api/bot-users/{chat_id}/active-trip", response_model=BotUserResponse, tags=["Bot Users"])
+async def set_bot_user_active_trip(
+    chat_id: int,
+    trip_id: Optional[str] = None,
+    db: AsyncSession = Depends(get_db)
+):
+    """Set or clear active trip for driver"""
+    repo = BotUserRepository(db)
+    bot_user = await repo.get_by_chat_id(chat_id)
+
+    if not bot_user or not bot_user.driver_id:
+        raise HTTPException(status_code=404, detail="Bot user not registered as driver")
+
+    bot_user = await repo.set_active_trip(chat_id, trip_id)
+
+    if trip_id:
+        logger.info(f"Bot user {chat_id} started trip {trip_id}")
+    else:
+        logger.info(f"Bot user {chat_id} cleared active trip")
+
+    return bot_user
+
+
 # ========== TASK #41: TRIP REQUESTS ==========
 
 @app.post("/api/v1/trip-requests/send", status_code=status.HTTP_202_ACCEPTED, tags=["Trip Requests"])
@@ -335,7 +570,7 @@ def get_trip_request(trip_id: str):
 @app.get("/drivers/{driver_id}/trips")
 async def get_driver_trips(driver_id: str):
     """
-    Get available trips for driver (pending trips)
+    Get available trips for driver (only pending trips that are not yet assigned)
     Used by Telegram bot "My Orders" button
     """
     # Use storage from app.state (shared with consumers), fallback to globals
@@ -353,7 +588,8 @@ async def get_driver_trips(driver_id: str):
     if driver_id not in drivers_storage:
         raise HTTPException(status_code=404, detail="Driver not found")
 
-    # Get pending trips (available for all drivers) and assigned trips for this driver
+    # Get only PENDING trips (not assigned yet)
+    # Exclude assigned/completed trips to prevent showing them again
     available_trips = []
     for trip_id, trip_data in trip_requests_storage.items():
         status = trip_data.get("status")
@@ -361,13 +597,12 @@ async def get_driver_trips(driver_id: str):
 
         logger.info(f"  Trip {trip_id}: status={status}, assigned_driver={assigned_driver_id}")
 
-        # Include if: pending OR (assigned to this driver)
-        if status == "pending" or (status == "assigned" and assigned_driver_id == driver_id):
+        # Include ONLY pending trips (not yet assigned to anyone)
+        if status == "pending":
             pickup_data = trip_data.get("pickup", {})
             dropoff_data = trip_data.get("dropoff", {})
 
-            trip_status = "PENDING" if status == "pending" else "ACTIVE"
-            logger.info(f"  ✅ Trip {trip_id}: {trip_status}, pickup={pickup_data}, dropoff={dropoff_data}")
+            logger.info(f"  ✅ Trip {trip_id}: PENDING, pickup={pickup_data}, dropoff={dropoff_data}")
 
             available_trips.append({
                 "trip_id": trip_id,
@@ -375,12 +610,12 @@ async def get_driver_trips(driver_id: str):
                 "dropoff": dropoff_data.get("address", "N/A"),
                 "pickup_address": pickup_data.get("address", "N/A"),
                 "dropoff_address": dropoff_data.get("address", "N/A"),
-                "status": trip_status,
+                "status": "PENDING",
                 "comment": None,
                 "created_at": trip_data.get("created_at", "")
             })
         else:
-            logger.info(f"  ❌ Trip {trip_id}: status={status}, assigned_to={assigned_driver_id}, skipping")
+            logger.info(f"  ❌ Trip {trip_id}: status={status}, assigned_to={assigned_driver_id}, skipping (not pending)")
 
     logger.info(f"Driver {driver_id} requested trips: {len(available_trips)} available")
 
@@ -391,7 +626,7 @@ async def get_driver_trips(driver_id: str):
 
 
 @app.post("/drivers/{driver_id}/trips/{trip_id}/accept")
-async def accept_trip(driver_id: str, trip_id: str):
+async def accept_trip(driver_id: str, trip_id: str, db: AsyncSession = Depends(get_db)):
     """
     Driver accepts trip request
     Used by Telegram bot "Accept" button
@@ -406,9 +641,27 @@ async def accept_trip(driver_id: str, trip_id: str):
     drivers_storage = app.state.drivers_storage
     trip_requests_storage = app.state.trip_requests_storage
 
-    # Verify driver exists
-    if driver_id not in drivers_storage:
-        raise HTTPException(status_code=404, detail="Driver not found")
+    # Verify driver exists in database and sync to memory if needed
+    from uuid import UUID
+    try:
+        driver_uuid = UUID(driver_id)
+        driver_repo = DriverRepository(db)
+        driver = await driver_repo.get_by_id(driver_uuid)
+        if not driver:
+            raise HTTPException(status_code=404, detail="Driver not found in database")
+
+        # Ensure driver is in memory storage
+        if driver_id not in drivers_storage:
+            logger.warning(f"Driver {driver_id} not in memory storage, adding now")
+            drivers_storage[driver_id] = {
+                "id": driver_id,
+                "name": f"{driver.first_name} {driver.last_name}",
+                "status": "ONLINE" if driver.is_active else "OFFLINE",
+                "latitude": 50.4501,
+                "longitude": 30.5234
+            }
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid driver ID format")
 
     # Verify trip exists
     if trip_id not in trip_requests_storage:
@@ -445,7 +698,7 @@ async def accept_trip(driver_id: str, trip_id: str):
 
 
 @app.post("/drivers/{driver_id}/trips/{trip_id}/reject")
-async def reject_trip(driver_id: str, trip_id: str):
+async def reject_trip(driver_id: str, trip_id: str, db: AsyncSession = Depends(get_db)):
     """
     Driver rejects trip request
     Used by Telegram bot "Reject" button
@@ -460,9 +713,27 @@ async def reject_trip(driver_id: str, trip_id: str):
     drivers_storage = app.state.drivers_storage
     trip_requests_storage = app.state.trip_requests_storage
 
-    # Verify driver exists
-    if driver_id not in drivers_storage:
-        raise HTTPException(status_code=404, detail="Driver not found")
+    # Verify driver exists in database and sync to memory if needed
+    from uuid import UUID
+    try:
+        driver_uuid = UUID(driver_id)
+        driver_repo = DriverRepository(db)
+        driver = await driver_repo.get_by_id(driver_uuid)
+        if not driver:
+            raise HTTPException(status_code=404, detail="Driver not found in database")
+
+        # Ensure driver is in memory storage
+        if driver_id not in drivers_storage:
+            logger.warning(f"Driver {driver_id} not in memory storage, adding now")
+            drivers_storage[driver_id] = {
+                "id": driver_id,
+                "name": f"{driver.first_name} {driver.last_name}",
+                "status": "ONLINE" if driver.is_active else "OFFLINE",
+                "latitude": 50.4501,
+                "longitude": 30.5234
+            }
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid driver ID format")
 
     # Verify trip exists
     if trip_id not in trip_requests_storage:
@@ -490,32 +761,47 @@ async def reject_trip(driver_id: str, trip_id: str):
 
 
 @app.post("/drivers/{driver_id}/trips/{trip_id}/complete")
-async def complete_trip(driver_id: str, trip_id: str):
+async def complete_trip(driver_id: str, trip_id: str, db: AsyncSession = Depends(get_db)):
     """
     Driver completes trip
     Used by Telegram bot "Finish Trip" button
     """
     from datetime import datetime, timezone
+    from uuid import UUID
 
     # Use storage from app.state
     drivers_storage = app.state.drivers_storage
     trip_requests_storage = app.state.trip_requests_storage
 
-    # Verify driver exists
-    if driver_id not in drivers_storage:
-        raise HTTPException(status_code=404, detail="Driver not found")
+    # Verify driver exists in database
+    try:
+        driver_uuid = UUID(driver_id)
+        driver_repo = DriverRepository(db)
+        driver = await driver_repo.get_by_id(driver_uuid)
+        if not driver:
+            raise HTTPException(status_code=404, detail="Driver not found in database")
 
-    # Verify trip exists
-    if trip_id not in trip_requests_storage:
-        logger.warning(f"Trip {trip_id} not found in storage. Available trips: {list(trip_requests_storage.keys())}")
-        raise HTTPException(status_code=404, detail="Trip request not found")
+        # Ensure driver is in memory storage for RabbitMQ events
+        if driver_id not in drivers_storage:
+            logger.warning(f"Driver {driver_id} not in memory storage, adding now")
+            drivers_storage[driver_id] = {
+                "id": driver_id,
+                "name": f"{driver.first_name} {driver.last_name}",
+                "status": "ONLINE" if driver.is_active else "OFFLINE",
+                "latitude": 50.4501,
+                "longitude": 30.5234
+            }
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid driver ID format")
 
-    # Save previous status for rollback in case of event publishing failure
-    previous_status = trip_requests_storage[trip_id]["status"]
-
-    # Update trip status to completed
-    trip_requests_storage[trip_id]["status"] = "completed"
-    logger.info(f"Trip {trip_id} marked as completed by driver {driver_id} (previous status: {previous_status})")
+    # Update local storage if trip exists there
+    previous_status = None
+    if trip_id in trip_requests_storage:
+        previous_status = trip_requests_storage[trip_id]["status"]
+        trip_requests_storage[trip_id]["status"] = "completed"
+        logger.info(f"Trip {trip_id} marked as completed in local storage by driver {driver_id} (previous status: {previous_status})")
+    else:
+        logger.info(f"Trip {trip_id} not in local storage (likely after restart), will send completion event to trip-service")
 
     # Track event publishing status
     event_published = False
@@ -565,24 +851,31 @@ async def complete_trip(driver_id: str, trip_id: str):
                     await asyncio.sleep(retry_delay)
                     retry_delay *= 2  # Double the delay for next attempt
                 else:
-                    # All retries failed - rollback the status change
-                    logger.error(
-                        f"🔄 Rolling back trip {trip_id} status from 'completed' to '{previous_status}' "
-                        f"due to event publishing failure after {max_retries} attempts"
-                    )
-                    trip_requests_storage[trip_id]["status"] = previous_status
+                    # All retries failed - rollback the status change if trip is in local storage
+                    if trip_id in trip_requests_storage and previous_status:
+                        logger.error(
+                            f"🔄 Rolling back trip {trip_id} status from 'completed' to '{previous_status}' "
+                            f"due to event publishing failure after {max_retries} attempts"
+                        )
+                        trip_requests_storage[trip_id]["status"] = previous_status
+                    else:
+                        logger.error(
+                            f"❌ Failed to publish trip completion event for trip {trip_id} after {max_retries} attempts. "
+                            f"Trip not in local storage, cannot rollback."
+                        )
 
                     event_warning = (
                         f"Trip status could not be synchronized with trip-service due to messaging failure. "
-                        f"Status rolled back to '{previous_status}'. Please try again or contact support."
+                        f"Please try again or contact support."
                     )
 
     # Build response with warning if event publishing failed
+    current_status = trip_requests_storage[trip_id]["status"] if trip_id in trip_requests_storage else "unknown"
     response = {
         "message": "Trip completed successfully" if event_published else "Trip completion failed - status not synchronized",
         "trip_id": trip_id,
         "driver_id": driver_id,
-        "status": trip_requests_storage[trip_id]["status"],
+        "status": current_status,
         "event_published": event_published
     }
 

--- a/driver-service/src/schemas/bot_user_schemas.py
+++ b/driver-service/src/schemas/bot_user_schemas.py
@@ -1,0 +1,47 @@
+"""Pydantic schemas for BotUser model"""
+from pydantic import BaseModel, Field
+from typing import Optional
+from uuid import UUID
+from datetime import datetime
+
+
+class BotUserBase(BaseModel):
+    """Base schema with common fields"""
+    telegram_chat_id: int = Field(..., description="Telegram chat ID of the user")
+    current_role: str = Field(default='passenger', description="Current active role: 'driver' or 'passenger'")
+
+
+class BotUserCreate(BotUserBase):
+    """Schema for creating a new bot user"""
+    pass
+
+
+class BotUserUpdate(BaseModel):
+    """Schema for updating bot user (all fields optional)"""
+    current_role: Optional[str] = None
+    driver_id: Optional[UUID] = None
+    driver_name: Optional[str] = None
+    car_description: Optional[str] = None
+    driver_status: Optional[str] = None
+    active_trip_id: Optional[str] = None
+
+
+class BotUserResponse(BotUserBase):
+    """Schema for returning bot user data"""
+    driver_id: Optional[UUID] = None
+    driver_name: Optional[str] = None
+    car_description: Optional[str] = None
+    driver_status: str
+    active_trip_id: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class BotUserDriverRegistration(BaseModel):
+    """Schema for registering user as driver"""
+    telegram_chat_id: int
+    driver_name: str = Field(..., min_length=2, max_length=100)
+    car_description: str = Field(..., min_length=5, max_length=200)

--- a/driver-service/src/services/bot_user_repository.py
+++ b/driver-service/src/services/bot_user_repository.py
@@ -1,0 +1,130 @@
+"""Repository for BotUser database operations"""
+import logging
+from typing import Optional, List
+from uuid import UUID
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.exc import IntegrityError
+from src.driver_models import BotUser
+
+logger = logging.getLogger(__name__)
+
+
+class BotUserRepository:
+    """Repository for managing bot users in the database"""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def get_by_chat_id(self, chat_id: int) -> Optional[BotUser]:
+        """Get bot user by telegram chat ID"""
+        stmt = select(BotUser).where(BotUser.telegram_chat_id == chat_id)
+        result = await self.db.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def create(self, **kwargs) -> BotUser:
+        """Create a new bot user"""
+        bot_user = BotUser(**kwargs)
+        self.db.add(bot_user)
+        await self.db.commit()
+        await self.db.refresh(bot_user)
+        logger.info(f"Created bot user with chat_id={bot_user.telegram_chat_id}")
+        return bot_user
+
+    async def update(self, chat_id: int, **kwargs) -> Optional[BotUser]:
+        """Update bot user fields"""
+        stmt = (
+            update(BotUser)
+            .where(BotUser.telegram_chat_id == chat_id)
+            .values(**kwargs)
+            .returning(BotUser)
+        )
+        result = await self.db.execute(stmt)
+        await self.db.commit()
+        updated = result.scalar_one_or_none()
+
+        if updated:
+            logger.info(f"Updated bot user chat_id={chat_id} with fields: {kwargs.keys()}")
+        else:
+            logger.warning(f"Bot user with chat_id={chat_id} not found for update")
+
+        return updated
+
+    async def get_or_create(self, chat_id: int, defaults: Optional[dict] = None) -> tuple[BotUser, bool]:
+        """
+        Get bot user by chat_id, or create if doesn't exist.
+        Returns (bot_user, created) where created is True if new user was created.
+
+        Race-safe: handles concurrent creation attempts by catching IntegrityError
+        and retrieving the existing record.
+        """
+        bot_user = await self.get_by_chat_id(chat_id)
+        if bot_user:
+            return bot_user, False
+
+        # Create new user with defaults
+        create_data = {'telegram_chat_id': chat_id}
+        if defaults:
+            create_data.update(defaults)
+
+        try:
+            bot_user = await self.create(**create_data)
+            return bot_user, True
+        except IntegrityError:
+            # Race condition: another process created the user between our check and create
+            # Rollback the failed transaction and retrieve the existing user
+            await self.db.rollback()
+            logger.info(f"Concurrent creation detected for chat_id={chat_id}, retrieving existing user")
+
+            bot_user = await self.get_by_chat_id(chat_id)
+            if bot_user:
+                return bot_user, False
+            else:
+                # This should never happen, but re-raise if it does
+                logger.error(f"Failed to retrieve user after IntegrityError for chat_id={chat_id}")
+                raise
+
+    async def list_all(self) -> List[BotUser]:
+        """Get all bot users"""
+        stmt = select(BotUser)
+        result = await self.db.execute(stmt)
+        return list(result.scalars().all())
+
+    async def delete(self, chat_id: int) -> bool:
+        """Delete bot user by chat_id"""
+        bot_user = await self.get_by_chat_id(chat_id)
+        if not bot_user:
+            return False
+
+        await self.db.delete(bot_user)
+        await self.db.commit()
+        logger.info(f"Deleted bot user with chat_id={chat_id}")
+        return True
+
+    async def update_driver_registration(
+        self,
+        chat_id: int,
+        driver_id: UUID,
+        driver_name: str,
+        car_description: str
+    ) -> Optional[BotUser]:
+        """Update bot user with driver registration info"""
+        return await self.update(
+            chat_id,
+            driver_id=driver_id,
+            driver_name=driver_name,
+            car_description=car_description,
+            current_role='driver'
+        )
+
+    async def update_role(self, chat_id: int, role: str) -> Optional[BotUser]:
+        """Update user's current role"""
+        return await self.update(chat_id, current_role=role)
+
+    async def update_driver_status(self, chat_id: int, status: str) -> Optional[BotUser]:
+        """Update driver's online/offline status"""
+        return await self.update(chat_id, driver_status=status)
+
+    async def set_active_trip(self, chat_id: int, trip_id: Optional[str]) -> Optional[BotUser]:
+        """Set or clear active trip for driver"""
+        return await self.update(chat_id, active_trip_id=trip_id)


### PR DESCRIPTION
…144)

* feat: implement persistent bot user profiles with database storage

  Add database-backed user profile storage to preserve driver data across role switches.
  Users can now switch between driver and passenger roles without losing registration data.

  Backend changes:
  - Add BotUser model to store Telegram user profiles in PostgreSQL
  - Create Alembic migration for bot_users table with foreign key to drivers
  - Add BotUserRepository for database operations
  - Implement 7 new API endpoints for bot user management
  - Add Pydantic schemas for bot user validation
  - Update psycopg2-binary to 2.9.10 in Dockerfile.migrations

  Frontend changes:
  - Integrate bot with new API endpoints via APIClient
  - Update driver registration flow to use persistent storage
  - Update role switching logic to preserve data in database
  - Refactor driver.py handlers (select_role, go_online/offline, show_orders, accept_trip, finish_trip) to use API

* fix: resolve driver state sync and trip filtering issues

  - Fix get_user_menu coroutine serialization error
  - Update all driver handlers to use persistent API instead of in-memory state
  - Filter only PENDING trips to prevent showing already accepted orders
  - Add database validation in trip endpoints with auto-sync to memory
  - Fix trip completion to work after service restart

* fix: remove unused register_driver_in_service variable

* test: update driver registration tests to use APIClient mocks

  Updated all test cases in test_driver_registration.py to mock APIClient
  methods instead of the deprecated helper functions. Tests now properly
  validate the refactored driver registration flow that uses persistent
  storage via the API instead of in-memory dictionaries.

  Changes:
  - Added mock_api_client fixture to mock all APIClient methods
  - Removed references to deprecated helper functions (register_driver_in_service, update_driver_status)
  - Updated test assertions to verify APIClient method calls
  - Removed dependencies on main.user_roles dictionary since data is now API-backed
  - Added proper mock configurations for get_bot_user, register_bot_user_as_driver, update_bot_user_driver_status
  - Updated trip-related tests to mock bot user state via API responses

* fix: linter fix

* fix: fix tests

* fix: coderabbit nitpick fix