### PR TITLE
fix: change package manager from dnf to apt

### DIFF
--- a/infra/terraform/modules/compute/data.tf
+++ b/infra/terraform/modules/compute/data.tf
@@ -1,12 +1,7 @@
-data "aws_ssm_parameter" "al2023_ami" {
-  count = var.ami == null ? 1 : 0
-  name  = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
-}
-
 data "aws_region" "current" {}
 
 locals {
-  resolved_ami = var.ami != null ? var.ami : data.aws_ssm_parameter.al2023_ami[0].value
+  resolved_ami = var.ami
 
   # Construct permissions boundary from account_id (DevOpsBound is required in this account)
   permissions_boundary = var.account_id != null ? "arn:aws:iam::${var.account_id}:policy/DevOpsBound" : null
@@ -40,7 +35,7 @@ locals {
 
     # Start Docker
     systemctl enable --now docker
-    usermod -aG docker admin
+    usermod -aG docker ${var.default_user}
 
     # Create service working directory
     mkdir -p /opt/${var.name}

--- a/infra/terraform/modules/compute/variables.tf
+++ b/infra/terraform/modules/compute/variables.tf
@@ -14,9 +14,14 @@ variable "subnet_id" {
 }
 
 variable "ami" {
-  description = "AMI ID for the EC2 instance (null = auto-select latest Amazon Linux 2023)"
+  description = "AMI ID for the EC2 instance"
   type        = string
-  default     = null
+}
+
+variable "default_user" {
+  description = "Default OS user on the AMI (e.g. admin for Debian, ubuntu for Ubuntu, ec2-user for AL2023)"
+  type        = string
+  default     = "admin"
 }
 
 variable "instance_type" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched compute nodes to apt-based Docker installation and service enablement.
  * Removed direct binary install of Docker Compose plugin; now uses packaged components.
  * Updated Docker user/group management to use a configurable default user.
  * Made AMI selection use the provided AMI value by default (no implicit null).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->