### PR TITLE
fix: add test variables for ECR and RDS in driver service infra tests

### DIFF
--- a/infra/terratest/driver_service_test.go
+++ b/infra/terratest/driver_service_test.go
@@ -37,6 +37,10 @@ func TestDriverServiceInfra(t *testing.T) {
 		"common_tags": map[string]string{
 			"Test": "true",
 		},
+		"github_repo":         "UA-4697-DevOps/drive-ops",
+		"db_identifier":       "drive-ops-test-db",
+		"rds_master_username": "test_admin",
+		"discord_webhook_url": "https://discord.com/api/webhooks/123456789/test-token",
 	}, region)
 
 	planStruct := terraform.InitAndPlanAndShowWithStruct(t, terraformOptions)


### PR DESCRIPTION
This pull request makes a minor update to the test configuration in `driver_service_test.go` by adding new variables to the test input map. These additions help ensure the test environment more closely matches production-like settings. 

- Test configuration updates:
  * Added `github_repo`, `db_identifier`, `rds_master_username`, and `discord_webhook_url` variables to the Terraform test options in `TestDriverServiceInfra`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure configuration with additional parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->