### PR TITLE
remove EC2 SSM action from trip deployment action

### DIFF
--- a/.github/workflows/deploy-trip-service.yml
+++ b/.github/workflows/deploy-trip-service.yml
@@ -58,7 +58,6 @@ jobs:
           push: true
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ inputs.image_tag }}
-            ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
Removed EC2 SSM action, now the deploy button will only build and push trip service image to ECR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced multi-step deploy with a single Docker build-and-push pipeline that tags (including latest), caches builds, and publishes images to ECR.
  * Removed environment deploy, verification, rollback and health-check steps; simplified summary to show the published image URI.
  * Updated job name, input description for image tag, and removed a public SERVICE_PORT environment declaration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->