### PR TITLE
Implement autoscaling for driver service in production and staging

### DIFF
--- a/driver-service/charts/driver-service/values-prod.yaml
+++ b/driver-service/charts/driver-service/values-prod.yaml
@@ -21,8 +21,9 @@ resources:
 autoscaling:
   enabled: true
   minReplicas: 2
-  maxReplicas: 6
+  maxReplicas: 3
   targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
 
 config:
   awsRegion: "us-east-2"

--- a/driver-service/charts/driver-service/values-staging.yaml
+++ b/driver-service/charts/driver-service/values-staging.yaml
@@ -19,7 +19,11 @@ resources:
     memory: 256Mi
 
 autoscaling:
-  enabled: false
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 2
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
 
 config:
   awsRegion: "us-east-2"

--- a/infra/k8s/argocd/apps/cluster-autoscaler.yaml
+++ b/infra/k8s/argocd/apps/cluster-autoscaler.yaml
@@ -1,0 +1,49 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cluster-autoscaler
+  namespace: argocd
+spec:
+  project: default
+
+  source:
+    repoURL: https://kubernetes.github.io/autoscaler
+    chart: cluster-autoscaler
+    targetRevision: 9.43.2
+    helm:
+      values: |
+        autoDiscovery:
+          clusterName: drive-ops-dev
+        awsRegion: us-east-2
+        rbac:
+          serviceAccount:
+            create: true
+            name: cluster-autoscaler
+            annotations:
+              # After running: cd infra/terragrunt/envs/dev/cluster-autoscaler && terragrunt apply
+              # Retrieve with: terragrunt output -raw role_arn
+              eks.amazonaws.com/role-arn: "" # Replace with Cluster Autoscaler IRSA role ARN
+        extraArgs:
+          balance-similar-node-groups: true
+          skip-nodes-with-system-pods: false
+          expander: least-waste
+          scale-down-delay-after-add: 5m
+          scale-down-unneeded-time: 5m
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ApplyOutOfSyncOnly=true

--- a/infra/k8s/argocd/apps/metrics-server.yaml
+++ b/infra/k8s/argocd/apps/metrics-server.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: metrics-server
+  namespace: argocd
+spec:
+  project: default
+
+  source:
+    repoURL: https://kubernetes-sigs.github.io/metrics-server
+    chart: metrics-server
+    targetRevision: 3.12.2
+    helm:
+      values: |
+        args:
+          - --kubelet-preferred-address-types=InternalIP
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ApplyOutOfSyncOnly=true


### PR DESCRIPTION
This pull request introduces important improvements to Kubernetes infrastructure and autoscaling for the `driver-service`. The main changes include enabling and tuning autoscaling for the driver service in staging and production, and adding ArgoCD applications for `metrics-server` and `cluster-autoscaler`, which are essential for dynamic scaling and resource monitoring.

**Autoscaling configuration updates:**

* Enabled autoscaling for the driver service in staging, setting `minReplicas` to 1, `maxReplicas` to 2, and specifying CPU and memory utilization targets.
* Reduced the maximum number of replicas for autoscaling in production from 6 to 3 and added a memory utilization target.

**Kubernetes infrastructure enhancements:**

* Added an ArgoCD application manifest for `metrics-server` to the infrastructure, which is necessary for gathering resource metrics used by the Horizontal Pod Autoscaler.
* Added an ArgoCD application manifest for `cluster-autoscaler`, including configuration for AWS integration and resource settings, enabling automatic scaling of cluster nodes based on workload demand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated driver service autoscaling configuration with adjusted replica counts and memory utilization targets across production and staging environments.
  * Deployed Kubernetes Cluster Autoscaler for automatic cluster node scaling management.
  * Deployed Metrics Server for enhanced cluster metrics collection and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->