### PR TITLE
Implement modular EC2 infrastructure for NAT and compute resources

### DIFF
--- a/infra/terraform/modules/bastion/main.tf
+++ b/infra/terraform/modules/bastion/main.tf
@@ -71,17 +71,7 @@ resource "aws_iam_instance_profile" "bastion" {
   })
 }
 
-# --- Elastic IP (allocated first so it can be referenced in outputs) ---
-
-resource "aws_eip" "bastion" {
-  domain = "vpc"
-
-  tags = merge(var.tags, {
-    Name = "${var.project_name}-${var.env}-bastion-eip"
-  })
-}
-
-# --- EC2 Instance ---
+# --- EC2 Instance + Elastic IP ---
 
 module "ec2" {
   source = "../ec2-instance"
@@ -96,6 +86,7 @@ module "ec2" {
   monitoring             = true
   user_data              = file("${path.module}/scripts/user-data.sh")
   metadata_hop_limit     = 1
+  create_eip             = true
 
   tags = var.tags
 }
@@ -106,10 +97,12 @@ moved {
   to   = module.ec2.aws_instance.this
 }
 
-# --- Associate EIP with Instance ---
-
-resource "aws_eip_association" "bastion" {
-  instance_id   = module.ec2.instance_id
-  allocation_id = aws_eip.bastion.id
+moved {
+  from = aws_eip.bastion
+  to   = module.ec2.aws_eip.this[0]
 }
 
+moved {
+  from = aws_eip_association.bastion
+  to   = module.ec2.aws_eip_association.this[0]
+}

--- a/infra/terraform/modules/bastion/main.tf
+++ b/infra/terraform/modules/bastion/main.tf
@@ -83,7 +83,10 @@ resource "aws_eip" "bastion" {
 
 # --- EC2 Instance ---
 
-resource "aws_instance" "bastion" {
+module "ec2" {
+  source = "../ec2-instance"
+
+  name                   = "${var.project_name}-${var.env}-bastion"
   ami                    = data.aws_ami.al2023.id
   instance_type          = var.instance_type
   subnet_id              = var.public_subnet_id
@@ -91,38 +94,22 @@ resource "aws_instance" "bastion" {
   key_name               = var.key_name
   iam_instance_profile   = aws_iam_instance_profile.bastion.name
   monitoring             = true
+  user_data              = file("${path.module}/scripts/user-data.sh")
+  metadata_hop_limit     = 1
 
-  user_data = file("${path.module}/scripts/user-data.sh")
+  tags = var.tags
+}
 
-  metadata_options {
-    http_endpoint               = "enabled"
-    http_tokens                 = "required" # IMDSv2 only
-    http_put_response_hop_limit = 1
-  }
-
-  root_block_device {
-    volume_size = 30
-    volume_type = "gp3"
-    encrypted   = true
-  }
-
-  tags = merge(var.tags, {
-    Name = "${var.project_name}-${var.env}-bastion"
-  })
-
-  depends_on = [
-    aws_iam_role_policy_attachment.bastion_ssm,
-    aws_iam_instance_profile.bastion,
-  ]
-
-  lifecycle {
-    ignore_changes = [ami]
-  }
+# --- State Migration ---
+moved {
+  from = aws_instance.bastion
+  to   = module.ec2.aws_instance.this
 }
 
 # --- Associate EIP with Instance ---
 
 resource "aws_eip_association" "bastion" {
-  instance_id   = aws_instance.bastion.id
+  instance_id   = module.ec2.instance_id
   allocation_id = aws_eip.bastion.id
 }
+

--- a/infra/terraform/modules/bastion/outputs.tf
+++ b/infra/terraform/modules/bastion/outputs.tf
@@ -5,7 +5,7 @@ output "bastion_public_ip" {
 
 output "bastion_instance_id" {
   description = "Instance ID of the bastion host"
-  value       = aws_instance.bastion.id
+  value       = module.ec2.instance_id
 }
 
 output "bastion_security_group_id" {

--- a/infra/terraform/modules/bastion/outputs.tf
+++ b/infra/terraform/modules/bastion/outputs.tf
@@ -1,6 +1,6 @@
 output "bastion_public_ip" {
   description = "Elastic IP address of the bastion host"
-  value       = aws_eip.bastion.public_ip
+  value       = module.ec2.eip_public_ip
 }
 
 output "bastion_instance_id" {

--- a/infra/terraform/modules/compute/main.tf
+++ b/infra/terraform/modules/compute/main.tf
@@ -1,4 +1,7 @@
-resource "aws_instance" "this" {
+module "ec2" {
+  source = "../ec2-instance"
+
+  name                        = var.name
   ami                         = local.resolved_ami
   instance_type               = var.instance_type
   subnet_id                   = var.subnet_id
@@ -10,34 +13,16 @@ resource "aws_instance" "this" {
   user_data                   = local.resolved_user_data
   disable_api_termination     = var.enable_termination_protection
 
-  root_block_device {
-    volume_size           = var.root_volume_size
-    volume_type           = var.root_volume_type
-    delete_on_termination = true
-    encrypted             = true
+  root_volume_size = var.root_volume_size
+  root_volume_type = var.root_volume_type
 
-    tags = merge(var.tags, {
-      Name = "${var.name}-root-volume"
-    })
-  }
+  tags = var.tags
+}
 
-  metadata_options {
-    http_endpoint               = "enabled"
-    http_tokens                 = "required"
-    http_put_response_hop_limit = 2
-    instance_metadata_tags      = "enabled"
-  }
-
-  tags = merge(var.tags, {
-    Name = var.name
-  })
-
-  # --- CRITICAL UPDATE ---
-  lifecycle {
-    ignore_changes = [
-      ami,
-    ]
-  }
+# --- State Migration ---
+moved {
+  from = aws_instance.this
+  to   = module.ec2.aws_instance.this
 }
 
 resource "aws_security_group_rule" "compute_ingress_internal" {

--- a/infra/terraform/modules/compute/outputs.tf
+++ b/infra/terraform/modules/compute/outputs.tf
@@ -1,16 +1,16 @@
 output "instance_id" {
   description = "ID of the EC2 instance"
-  value       = aws_instance.this.id
+  value       = module.ec2.instance_id
 }
 
 output "instance_public_ip" {
   description = "Public IP address of the EC2 instance"
-  value       = aws_instance.this.public_ip
+  value       = module.ec2.public_ip
 }
 
 output "instance_private_ip" {
   description = "Private IP address of the EC2 instance"
-  value       = aws_instance.this.private_ip
+  value       = module.ec2.private_ip
 }
 
 output "security_group_id" {

--- a/infra/terraform/modules/ec2-instance/main.tf
+++ b/infra/terraform/modules/ec2-instance/main.tf
@@ -4,10 +4,12 @@
 # A reusable, hardened EC2 instance with sensible defaults:
 #   - IMDSv2 enforced (http_tokens = "required")
 #   - Encrypted gp3 root volume
+#   - Optional Elastic IP for a stable public address
 #   - Lifecycle: ignore AMI drift (prevents accidental replacement)
 #
-# This module owns ONLY the aws_instance resource. IAM roles, security groups,
-# EIPs, and user_data scripts are the responsibility of the calling module.
+# This module owns the aws_instance and optionally an aws_eip + association.
+# IAM roles, security groups, and user_data scripts are the responsibility
+# of the calling module.
 # ==============================================================================
 
 resource "aws_instance" "this" {
@@ -61,4 +63,21 @@ resource "aws_instance" "this" {
       error_message = "root_volume_throughput is only valid when root_volume_type is gp3."
     }
   }
+}
+
+# --- Optional Elastic IP ---
+
+resource "aws_eip" "this" {
+  count  = var.create_eip ? 1 : 0
+  domain = "vpc"
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-eip"
+  })
+}
+
+resource "aws_eip_association" "this" {
+  count         = var.create_eip ? 1 : 0
+  instance_id   = aws_instance.this.id
+  allocation_id = aws_eip.this[0].id
 }

--- a/infra/terraform/modules/ec2-instance/main.tf
+++ b/infra/terraform/modules/ec2-instance/main.tf
@@ -1,0 +1,52 @@
+# ==============================================================================
+# EC2 INSTANCE MODULE
+# ==============================================================================
+# A reusable, hardened EC2 instance with sensible defaults:
+#   - IMDSv2 enforced (http_tokens = "required")
+#   - Encrypted gp3 root volume
+#   - Lifecycle: ignore AMI drift (prevents accidental replacement)
+#
+# This module owns ONLY the aws_instance resource. IAM roles, security groups,
+# EIPs, and user_data scripts are the responsibility of the calling module.
+# ==============================================================================
+
+resource "aws_instance" "this" {
+  ami                         = var.ami
+  instance_type               = var.instance_type
+  subnet_id                   = var.subnet_id
+  vpc_security_group_ids      = var.vpc_security_group_ids
+  key_name                    = var.key_name
+  iam_instance_profile        = var.iam_instance_profile
+  monitoring                  = var.monitoring
+  associate_public_ip_address = var.associate_public_ip_address
+  user_data                   = var.user_data
+  disable_api_termination     = var.disable_api_termination
+  source_dest_check           = var.source_dest_check
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required" # IMDSv2 only
+    http_put_response_hop_limit = var.metadata_hop_limit
+    instance_metadata_tags      = var.instance_metadata_tags ? "enabled" : "disabled"
+  }
+
+  root_block_device {
+    volume_size           = var.root_volume_size
+    volume_type           = var.root_volume_type
+    encrypted             = true # always encrypted
+    kms_key_id            = var.root_volume_kms_key_id
+    delete_on_termination = true
+
+    tags = merge(var.tags, {
+      Name = "${var.name}-root-volume"
+    })
+  }
+
+  tags = merge(var.tags, var.extra_tags, {
+    Name = var.name
+  })
+
+  lifecycle {
+    ignore_changes = [ami]
+  }
+}

--- a/infra/terraform/modules/ec2-instance/main.tf
+++ b/infra/terraform/modules/ec2-instance/main.tf
@@ -33,6 +33,8 @@ resource "aws_instance" "this" {
   root_block_device {
     volume_size           = var.root_volume_size
     volume_type           = var.root_volume_type
+    iops                  = var.root_volume_iops
+    throughput            = var.root_volume_type == "gp3" ? var.root_volume_throughput : null
     encrypted             = true # always encrypted
     kms_key_id            = var.root_volume_kms_key_id
     delete_on_termination = true
@@ -48,5 +50,15 @@ resource "aws_instance" "this" {
 
   lifecycle {
     ignore_changes = [ami]
+
+    precondition {
+      condition     = contains(["io1", "io2"], var.root_volume_type) ? var.root_volume_iops != null : true
+      error_message = "root_volume_iops must be provided when root_volume_type is io1 or io2."
+    }
+
+    precondition {
+      condition     = var.root_volume_throughput != null ? var.root_volume_type == "gp3" : true
+      error_message = "root_volume_throughput is only valid when root_volume_type is gp3."
+    }
   }
 }

--- a/infra/terraform/modules/ec2-instance/outputs.tf
+++ b/infra/terraform/modules/ec2-instance/outputs.tf
@@ -1,0 +1,28 @@
+# ==============================================================================
+# EC2 INSTANCE MODULE – OUTPUTS
+# ==============================================================================
+
+output "instance_id" {
+  description = "ID of the EC2 instance"
+  value       = aws_instance.this.id
+}
+
+output "public_ip" {
+  description = "Public IP address of the EC2 instance (null if no public IP)"
+  value       = aws_instance.this.public_ip
+}
+
+output "private_ip" {
+  description = "Private IP address of the EC2 instance"
+  value       = aws_instance.this.private_ip
+}
+
+output "primary_network_interface_id" {
+  description = "ID of the primary network interface (useful for NAT route targets)"
+  value       = aws_instance.this.primary_network_interface_id
+}
+
+output "arn" {
+  description = "ARN of the EC2 instance"
+  value       = aws_instance.this.arn
+}

--- a/infra/terraform/modules/ec2-instance/outputs.tf
+++ b/infra/terraform/modules/ec2-instance/outputs.tf
@@ -26,3 +26,13 @@ output "arn" {
   description = "ARN of the EC2 instance"
   value       = aws_instance.this.arn
 }
+
+output "eip_public_ip" {
+  description = "Elastic IP address (null if create_eip = false)"
+  value       = var.create_eip ? aws_eip.this[0].public_ip : null
+}
+
+output "eip_allocation_id" {
+  description = "Allocation ID of the Elastic IP (null if create_eip = false)"
+  value       = var.create_eip ? aws_eip.this[0].id : null
+}

--- a/infra/terraform/modules/ec2-instance/variables.tf
+++ b/infra/terraform/modules/ec2-instance/variables.tf
@@ -39,6 +39,14 @@ variable "vpc_security_group_ids" {
   }
 }
 
+# --- Optional: Networking ---
+
+variable "create_eip" {
+  description = "Allocate an Elastic IP and associate it with the instance (stable public address)"
+  type        = bool
+  default     = false
+}
+
 # --- Optional: Compute ---
 
 variable "instance_type" {

--- a/infra/terraform/modules/ec2-instance/variables.tf
+++ b/infra/terraform/modules/ec2-instance/variables.tf
@@ -138,6 +138,18 @@ variable "root_volume_kms_key_id" {
   default     = null
 }
 
+variable "root_volume_iops" {
+  description = "Amount of provisioned IOPS. Required for io1 and io2, optional for gp3."
+  type        = number
+  default     = null
+}
+
+variable "root_volume_throughput" {
+  description = "Throughput in MiB/s. Only valid for gp3."
+  type        = number
+  default     = null
+}
+
 # --- Optional: Tags ---
 
 variable "tags" {

--- a/infra/terraform/modules/ec2-instance/variables.tf
+++ b/infra/terraform/modules/ec2-instance/variables.tf
@@ -1,0 +1,153 @@
+# ==============================================================================
+# EC2 INSTANCE MODULE – VARIABLES
+# ==============================================================================
+
+# --- Required ---
+
+variable "name" {
+  description = "Name for the EC2 instance (used in the Name tag and root volume tag)"
+  type        = string
+
+  validation {
+    condition     = length(var.name) > 0
+    error_message = "name must not be empty."
+  }
+}
+
+variable "ami" {
+  description = "AMI ID for the EC2 instance"
+  type        = string
+
+  validation {
+    condition     = can(regex("^ami-[a-f0-9]{8,17}$", var.ami))
+    error_message = "ami must be a valid AMI ID (e.g., ami-0abcdef1234567890)."
+  }
+}
+
+variable "subnet_id" {
+  description = "Subnet ID to launch the instance in"
+  type        = string
+}
+
+variable "vpc_security_group_ids" {
+  description = "List of security group IDs to attach to the instance"
+  type        = list(string)
+
+  validation {
+    condition     = length(var.vpc_security_group_ids) > 0
+    error_message = "At least one security group ID must be provided."
+  }
+}
+
+# --- Optional: Compute ---
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t3.micro"
+}
+
+variable "key_name" {
+  description = "Name of an existing EC2 Key Pair for SSH access. null disables key-based SSH."
+  type        = string
+  default     = null
+}
+
+variable "iam_instance_profile" {
+  description = "Name of the IAM instance profile to attach"
+  type        = string
+  default     = null
+}
+
+variable "monitoring" {
+  description = "Enable detailed CloudWatch monitoring"
+  type        = bool
+  default     = false
+}
+
+variable "associate_public_ip_address" {
+  description = "Associate a public IP address with the instance"
+  type        = bool
+  default     = false
+}
+
+variable "user_data" {
+  description = "User data script to run on instance launch"
+  type        = string
+  default     = null
+}
+
+variable "disable_api_termination" {
+  description = "Enable EC2 termination protection"
+  type        = bool
+  default     = false
+}
+
+variable "source_dest_check" {
+  description = "Enable source/destination check. Set to false for NAT or VPN instances."
+  type        = bool
+  default     = true
+}
+
+# --- Optional: Metadata ---
+
+variable "metadata_hop_limit" {
+  description = "HTTP PUT response hop limit for IMDSv2. Use 1 for single-hop (bastion/NAT), 2 for containers."
+  type        = number
+  default     = 2
+
+  validation {
+    condition     = var.metadata_hop_limit >= 1 && var.metadata_hop_limit <= 64
+    error_message = "metadata_hop_limit must be between 1 and 64."
+  }
+}
+
+variable "instance_metadata_tags" {
+  description = "Make instance tags accessible via the instance metadata service"
+  type        = bool
+  default     = true
+}
+
+# --- Optional: Storage ---
+
+variable "root_volume_size" {
+  description = "Size of the root EBS volume in GB"
+  type        = number
+  default     = 30
+
+  validation {
+    condition     = var.root_volume_size >= 8
+    error_message = "root_volume_size must be at least 8 GB."
+  }
+}
+
+variable "root_volume_type" {
+  description = "Type of root EBS volume (gp3, gp2, io1, io2)"
+  type        = string
+  default     = "gp3"
+
+  validation {
+    condition     = contains(["gp3", "gp2", "io1", "io2"], var.root_volume_type)
+    error_message = "root_volume_type must be one of: gp3, gp2, io1, io2."
+  }
+}
+
+variable "root_volume_kms_key_id" {
+  description = "ARN of a KMS key for root volume encryption. null uses the default AWS-managed EBS key."
+  type        = string
+  default     = null
+}
+
+# --- Optional: Tags ---
+
+variable "tags" {
+  description = "Tags applied to the instance and root volume"
+  type        = map(string)
+  default     = {}
+}
+
+variable "extra_tags" {
+  description = "Additional tags merged after var.tags (e.g., Role = NAT). Useful for consumer-specific metadata."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/nat/main.tf
+++ b/infra/terraform/modules/nat/main.tf
@@ -57,15 +57,7 @@ resource "aws_iam_instance_profile" "nat_instance" {
   role  = aws_iam_role.nat_instance[0].name
 }
 
-resource "aws_eip" "nat_instance" {
-  count  = var.enabled ? 1 : 0
-  domain = "vpc"
-
-  tags = merge(var.tags, {
-    Name = "${var.project_name}-${var.env}-nat-instance-eip"
-  })
-}
-
+# Note: EIP will be created by the ec2 module when create_eip = true
 module "ec2" {
   source = "../ec2-instance"
   count  = var.enabled ? 1 : 0
@@ -86,6 +78,8 @@ module "ec2" {
   extra_tags = {
     Role = "NAT"
   }
+
+  create_eip = true
 }
 
 # --- State Migration ---
@@ -94,14 +88,14 @@ moved {
   to   = module.ec2[0].aws_instance.this
 }
 
-# ==============================================================================
-# EIP Association
-# ==============================================================================
+moved {
+  from = aws_eip.nat_instance[0]
+  to   = module.ec2[0].aws_eip.this[0]
+}
 
-resource "aws_eip_association" "nat_instance" {
-  count         = var.enabled ? 1 : 0
-  instance_id   = module.ec2[0].instance_id
-  allocation_id = aws_eip.nat_instance[0].id
+moved {
+  from = aws_eip_association.nat_instance[0]
+  to   = module.ec2[0].aws_eip_association.this[0]
 }
 
 resource "aws_route" "private_nat_instance" {

--- a/infra/terraform/modules/nat/main.tf
+++ b/infra/terraform/modules/nat/main.tf
@@ -66,8 +66,11 @@ resource "aws_eip" "nat_instance" {
   })
 }
 
-resource "aws_instance" "nat_instance" {
-  count                       = var.enabled ? 1 : 0
+module "ec2" {
+  source = "../ec2-instance"
+  count  = var.enabled ? 1 : 0
+
+  name                        = "${var.project_name}-${var.env}-nat-instance"
   ami                         = data.aws_ami.nat_instance.id
   instance_type               = var.instance_type
   subnet_id                   = var.public_subnet_id
@@ -76,29 +79,19 @@ resource "aws_instance" "nat_instance" {
   key_name                    = var.key_name
   associate_public_ip_address = true
   source_dest_check           = false
+  metadata_hop_limit          = 1
 
-  metadata_options {
-    http_endpoint               = "enabled"
-    http_tokens                 = "required"
-    http_put_response_hop_limit = 1
-    instance_metadata_tags      = "enabled"
-  }
+  tags = var.tags
 
-  root_block_device {
-    volume_type           = "gp3"
-    volume_size           = 30
-    encrypted             = true
-    delete_on_termination = true
-  }
-
-  tags = merge(var.tags, {
-    Name = "${var.project_name}-${var.env}-nat-instance"
+  extra_tags = {
     Role = "NAT"
-  })
-
-  lifecycle {
-    ignore_changes = [ami]
   }
+}
+
+# --- State Migration ---
+moved {
+  from = aws_instance.nat_instance[0]
+  to   = module.ec2[0].aws_instance.this
 }
 
 # ==============================================================================
@@ -107,7 +100,7 @@ resource "aws_instance" "nat_instance" {
 
 resource "aws_eip_association" "nat_instance" {
   count         = var.enabled ? 1 : 0
-  instance_id   = aws_instance.nat_instance[0].id
+  instance_id   = module.ec2[0].instance_id
   allocation_id = aws_eip.nat_instance[0].id
 }
 
@@ -115,6 +108,6 @@ resource "aws_route" "private_nat_instance" {
   count                  = var.enabled ? 1 : 0
   route_table_id         = var.private_route_table_id
   destination_cidr_block = "0.0.0.0/0"
-  network_interface_id   = aws_instance.nat_instance[0].primary_network_interface_id
-  depends_on             = [aws_instance.nat_instance]
+  network_interface_id   = module.ec2[0].primary_network_interface_id
+  depends_on             = [module.ec2]
 }

--- a/infra/terraform/modules/nat/outputs.tf
+++ b/infra/terraform/modules/nat/outputs.tf
@@ -5,7 +5,7 @@ output "nat_instance_id" {
 
 output "nat_instance_public_ip" {
   description = "Elastic IP address assigned to the NAT instance. null when enabled = false."
-  value       = try(aws_eip.nat_instance[0].public_ip, null)
+  value       = try(module.ec2[0].eip_public_ip, null)
 }
 
 output "nat_instance_private_ip" {

--- a/infra/terraform/modules/nat/outputs.tf
+++ b/infra/terraform/modules/nat/outputs.tf
@@ -1,6 +1,6 @@
 output "nat_instance_id" {
   description = "Instance ID of the NAT instance. null when enabled = false."
-  value       = try(aws_instance.nat_instance[0].id, null)
+  value       = try(module.ec2[0].instance_id, null)
 }
 
 output "nat_instance_public_ip" {
@@ -10,7 +10,7 @@ output "nat_instance_public_ip" {
 
 output "nat_instance_private_ip" {
   description = "Private IP address of the NAT instance within the VPC. null when enabled = false."
-  value       = try(aws_instance.nat_instance[0].private_ip, null)
+  value       = try(module.ec2[0].private_ip, null)
 }
 
 output "nat_security_group_id" {


### PR DESCRIPTION
This pull request introduces a new reusable `ec2-instance` Terraform module to standardize and harden the creation of EC2 instances across the infrastructure. It refactors the existing `bastion`, `nat`, and `compute` modules to use this new module, improving maintainability, security, and consistency. The migration is handled safely using Terraform's `moved` blocks to prevent resource recreation.

**Introduction of reusable EC2 instance module:**

- Added a new `infra/terraform/modules/ec2-instance` module that encapsulates best practices for EC2 instances, including IMDSv2 enforcement, encrypted root volumes, and AMI drift protection. The module exposes configurable variables and outputs for integration by other modules. [[1]](diffhunk://#diff-6e00573383ea99d210b9af722fb878e0d47b2a0c322f855462706add43d72d70R1-R52) [[2]](diffhunk://#diff-3e19cb74dccd0b4608fdddc6ca9c11138c8f6b37c0f920255ac5a69ad948917cR1-R153) [[3]](diffhunk://#diff-f4a0d50163a9e8d4651f626600c6a680785c70a655a131c943a17ca33d70f638R1-R28)

**Refactoring of existing modules to use the new module:**

- Updated the `bastion`, `nat`, and `compute` modules to replace direct usage of `aws_instance` with the new `ec2-instance` module, passing appropriate variables and wiring outputs accordingly. This change also updates EIP associations and route resources to reference the new module outputs. [[1]](diffhunk://#diff-4673ff2e0df605c54cc68275b8f18e6fa8471a369afee349870f07a0435e7680L86-R115) [[2]](diffhunk://#diff-8672f8c61bdf182c1243f40e11cee76a24f189be250b32193dd96aeb2ba67ba0L69-R73) [[3]](diffhunk://#diff-762bbf55b88b5fd521c76173959698618fbd45be180d2c37532105a8b1741295L1-R4) [[4]](diffhunk://#diff-762bbf55b88b5fd521c76173959698618fbd45be180d2c37532105a8b1741295L13-R25) [[5]](diffhunk://#diff-8672f8c61bdf182c1243f40e11cee76a24f189be250b32193dd96aeb2ba67ba0R82-R112)

**State migration for zero-downtime adoption:**

- Added `moved` blocks in each affected module to migrate Terraform state from the old `aws_instance` resources to the new module-based resources, preventing unnecessary instance replacement. [[1]](diffhunk://#diff-4673ff2e0df605c54cc68275b8f18e6fa8471a369afee349870f07a0435e7680L86-R115) [[2]](diffhunk://#diff-762bbf55b88b5fd521c76173959698618fbd45be180d2c37532105a8b1741295L13-R25) [[3]](diffhunk://#diff-8672f8c61bdf182c1243f40e11cee76a24f189be250b32193dd96aeb2ba67ba0R82-R112)

**Output rewiring:**

- Updated outputs in the `bastion`, `nat`, and `compute` modules to return values from the new `ec2-instance` module, ensuring consumers receive the correct instance details. [[1]](diffhunk://#diff-9a8861ee912cf6d5f3409c46c8344f72a3f9a960eca187e7c4e360ced000a598L8-R8) [[2]](diffhunk://#diff-bf98036f0b48b67b81ff543fd0e5bceab989e2b524490c06eb87d72153f3687fL3-R13) [[3]](diffhunk://#diff-2e30447ce824b1ab994cabd7e82b0c9e766abfd0e1334ce452ba47fde67169a5L3-R3) [[4]](diffhunk://#diff-2e30447ce824b1ab994cabd7e82b0c9e766abfd0e1334ce452ba47fde67169a5L13-R13)

**Tagging and metadata improvements:**

- Standardized tagging and metadata options via module variables, including support for extra tags and fine-grained metadata configuration (e.g., `metadata_hop_limit`, `instance_metadata_tags`). [[1]](diffhunk://#diff-8672f8c61bdf182c1243f40e11cee76a24f189be250b32193dd96aeb2ba67ba0R82-R112) [[2]](diffhunk://#diff-3e19cb74dccd0b4608fdddc6ca9c11138c8f6b37c0f920255ac5a69ad948917cR1-R153)

This refactor increases code reuse, enforces security best practices, and simplifies future maintenance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized EC2 instance configuration across bastion, compute, and NAT by extracting a reusable EC2 instance module and wiring existing modules to use it, reducing duplication and centralizing instance behavior.
  * Module now exposes instance identifiers and network outputs so other modules reference the unified instance outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->