### PR TITLE
Revert fix from commit a0ccc96

### DIFF
--- a/infra/k8s/manifests/external-secrets/driver-service-secret.yaml
+++ b/infra/k8s/manifests/external-secrets/driver-service-secret.yaml
@@ -10,7 +10,7 @@ spec:
     kind: ClusterSecretStore
   target:
     name: driver-service-secrets
-    creationPolicy: Merge
+    creationPolicy: Owner
   data:
     - secretKey: DB_USERNAME
       remoteRef:


### PR DESCRIPTION
This pull request makes a minor update to the `driver-service-secret.yaml` Kubernetes manifest. The `creationPolicy` for the external secret target is changed from `Merge` to `Owner`, which affects how the secret is managed and replaced in the cluster.This reverts commit a0ccc96dceee4bb2caede6a6ec7cb264fc069e35.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure configuration for secret management to improve consistency and reliability of system deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->