### PR TITLE
Update external secret configurations and database URL handling

### DIFF
--- a/driver-service/charts/driver-service/templates/external-secret.yaml
+++ b/driver-service/charts/driver-service/templates/external-secret.yaml
@@ -1,19 +1,33 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: {{.Values.database.secretName}}
-  namespace: {{.Release.Namespace}}
-  labels: {{- include "driver-service.labels" . | nindent 4}}
+  name: {{ .Values.database.secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "driver-service.labels" . | nindent 4 }}
 spec:
   refreshInterval: 1h
   secretStoreRef:
     name: aws-secrets-manager
     kind: ClusterSecretStore
   target:
-    name: {{.Values.database.secretName}}
+    name: {{ .Values.database.secretName }}
     creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # Render the exact key consumed by Deployment env var.
+        DATABASE_URL: "postgresql://{{ `{{ .DB_USER }}` }}:{{ `{{ .DB_PASSWORD }}` }}@{{ `{{ .RDS_ENDPOINT }}` }}/{{ .Values.externalSecret.databaseName }}"
   data:
-    - secretKey: {{.Values.database.secretKey}}
+    - secretKey: DB_USER
       remoteRef:
-        key: {{.Values.externalSecret.secretPath}}
-        property: {{.Values.externalSecret.property}}
+        key: {{ .Values.externalSecret.rdsSecretPath }}
+        property: {{ .Values.externalSecret.usernameProperty }}
+    - secretKey: DB_PASSWORD
+      remoteRef:
+        key: {{ .Values.externalSecret.rdsSecretPath }}
+        property: {{ .Values.externalSecret.passwordProperty }}
+    - secretKey: RDS_ENDPOINT
+      remoteRef:
+        key: {{ .Values.externalSecret.serviceSecretPath }}
+        property: {{ .Values.externalSecret.endpointProperty }}

--- a/driver-service/charts/driver-service/values-prod.yaml
+++ b/driver-service/charts/driver-service/values-prod.yaml
@@ -42,4 +42,5 @@ database:
   secretKey: "DATABASE_URL"
 
 externalSecret:
-  secretPath: "drive-ops/prod/rds/credentials"
+  rdsSecretPath: "drive-ops/prod/rds/credentials"
+  serviceSecretPath: "drive-ops/prod/driver-service"

--- a/driver-service/charts/driver-service/values-staging.yaml
+++ b/driver-service/charts/driver-service/values-staging.yaml
@@ -40,3 +40,7 @@ config:
 database:
   secretName: "driver-service-secrets"
   secretKey: "DATABASE_URL"
+
+externalSecret:
+  rdsSecretPath: "drive-ops/staging/rds/credentials"
+  serviceSecretPath: "drive-ops/staging/driver-service"

--- a/driver-service/charts/driver-service/values.yaml
+++ b/driver-service/charts/driver-service/values.yaml
@@ -116,8 +116,12 @@ secret:
   databaseUrl: ""
 
 externalSecret:
-  secretPath: "drive-ops/dev/rds/credentials"
-  property: "database-url"
+  rdsSecretPath: "drive-ops/dev/rds/credentials"
+  serviceSecretPath: "drive-ops/dev/driver-service"
+  usernameProperty: "username"
+  passwordProperty: "password"
+  endpointProperty: "RDS_ENDPOINT"
+  databaseName: "driver_db"
 
 ingress:
   enabled: false

--- a/infra/k8s/manifests/external-secrets/driver-service-secret.yaml
+++ b/infra/k8s/manifests/external-secrets/driver-service-secret.yaml
@@ -11,6 +11,10 @@ spec:
   target:
     name: driver-service-secrets
     creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        DATABASE_URL: "postgresql://{{ .DB_USERNAME }}:{{ .DB_PASSWORD }}@{{ .DB_HOST }}/{{ .DRIVER_DB_NAME }}"
   data:
     - secretKey: DB_USERNAME
       remoteRef:


### PR DESCRIPTION
This pull request updates how the `DATABASE_URL` secret is generated and managed for the driver service across environments. The changes improve secret templating, make secret references more explicit and flexible, and align naming conventions for consistency. The most important changes are grouped below:

**Secret templating and composition improvements:**

* Added a `template` section to the ExternalSecret manifests, using `engineVersion: v2`, to dynamically generate the `DATABASE_URL` from individual secret values (username, password, endpoint, and database name) instead of referencing a single property. This makes the secret more maintainable and secure. [[1]](diffhunk://#diff-ec76d14785d3348faa05f8756ef7ff2c8fc171d975de66405a5002b9d96bfe7bR16-R33) [[2]](diffhunk://#diff-d0c1ca6ec5a01664f3032bb3996b63d04d50dfeba5c739e2aa1c261370f52cccR14-R17)

**Secret reference restructuring and naming consistency:**

* Replaced the generic `secretPath` and `property` values in `values.yaml` with more explicit keys: `rdsSecretPath`, `serviceSecretPath`, `usernameProperty`, `passwordProperty`, `endpointProperty`, and `databaseName`. This clarifies which secrets are used and how they are mapped.
* Updated production and staging values files to use the new secret reference keys (`rdsSecretPath`, `serviceSecretPath`) for consistency across environments. [[1]](diffhunk://#diff-c6f3a5f3e41c719002bc8310ded24a1947c232c619a4c6a1cec614630c60c6a7L45-R46) [[2]](diffhunk://#diff-737792ff49a59b8958a9d8d474e4c60c78367ff38417c8b5eecae2f027aaeea5R43-R46)

**YAML formatting and label improvements:**

* Improved YAML formatting for the `labels` field in the ExternalSecret template for better readability and Helm compatibility.