### PR TITLE
Apply URL query filter to DATABASE_URL in external secrets

### DIFF
--- a/driver-service/charts/driver-service/templates/external-secret.yaml
+++ b/driver-service/charts/driver-service/templates/external-secret.yaml
@@ -17,7 +17,7 @@ spec:
       engineVersion: v2
       data:
         # Render the exact key consumed by Deployment env var.
-        DATABASE_URL: "postgresql://{{ `{{ .DB_USER }}` }}:{{ `{{ .DB_PASSWORD }}` }}@{{ `{{ .RDS_ENDPOINT }}` }}/{{ .Values.externalSecret.databaseName }}"
+        DATABASE_URL: "postgresql://{{ `{{ .DB_USER | urlquery }}` }}:{{ `{{ .DB_PASSWORD | urlquery }}` }}@{{ `{{ .RDS_ENDPOINT }}` }}/{{ .Values.externalSecret.databaseName }}"
   data:
     - secretKey: DB_USER
       remoteRef:

--- a/infra/k8s/manifests/external-secrets/driver-service-secret.yaml
+++ b/infra/k8s/manifests/external-secrets/driver-service-secret.yaml
@@ -16,7 +16,7 @@ spec:
     template:
       engineVersion: v2
       data:
-        DATABASE_URL: "postgresql://{{ .DB_USER }}:{{ .DB_PASSWORD }}@{{ .RDS_ENDPOINT }}/driver_db"
+        DATABASE_URL: "postgresql://{{ .DB_USER | urlquery }}:{{ .DB_PASSWORD | urlquery }}@{{ .RDS_ENDPOINT }}/driver_db"
   data:
     - secretKey: DB_USER
       remoteRef:


### PR DESCRIPTION
This pull request updates the way the `DATABASE_URL` is constructed in Kubernetes manifest templates for the driver service. The main change is to ensure that the database username and password are properly URL-encoded, which prevents issues if these values contain special characters.

**Improvements to secret handling:**

* Updated the `DATABASE_URL` template in `driver-service/charts/driver-service/templates/external-secret.yaml` to apply `urlquery` encoding to both `DB_USER` and `DB_PASSWORD`.
* Updated the `DATABASE_URL` template in `infra/k8s/manifests/external-secrets/driver-service-secret.yaml` to apply `urlquery` encoding to both `DB_USER` and `DB_PASSWORD`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Fixed handling of special characters in database credentials to ensure reliable connection establishment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->