### PR TITLE
Add security group rule for EKS nodes to access PostgreSQL

### DIFF
--- a/infra/terraform/modules/eks/main.tf
+++ b/infra/terraform/modules/eks/main.tf
@@ -154,6 +154,18 @@ resource "aws_security_group" "eks_nodes" {
   })
 }
 
+resource "aws_security_group_rule" "db_ingress_from_eks_nodes_postgres" {
+  count = var.db_security_group_id == null ? 0 : 1
+
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.eks_nodes.id
+  security_group_id        = var.db_security_group_id
+  description              = "Allow EKS worker nodes to reach PostgreSQL"
+}
+
 # ------------------------------------------------------------------------------
 # 2. CLOUDWATCH LOG GROUP (CONTROL PLANE LOGS)
 # ------------------------------------------------------------------------------

--- a/infra/terraform/modules/eks/variables.tf
+++ b/infra/terraform/modules/eks/variables.tf
@@ -53,6 +53,13 @@ variable "vpc_id" {
   type        = string
 }
 
+variable "db_security_group_id" {
+  description = "Security group ID of the RDS database. When set, allows EKS worker nodes to reach PostgreSQL on port 5432."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
 variable "private_subnet_ids" {
   description = "List of private subnet IDs for EKS worker nodes"
   type        = list(string)

--- a/infra/terragrunt/envs/dev/eks/terragrunt.hcl
+++ b/infra/terragrunt/envs/dev/eks/terragrunt.hcl
@@ -43,6 +43,7 @@ dependency "shared_infra" {
     vpc_id             = "vpc-mock-id"
     public_subnet_ids  = ["subnet-mock-pub-1", "subnet-mock-pub-2"]
     private_subnet_ids = ["subnet-mock-priv-1", "subnet-mock-priv-2"]
+    sg_db_id           = "sg-mock-db"
     kms_key_arn        = "arn:aws:kms:us-east-2:123456789012:key/mock-key-id"
   }
 }
@@ -70,6 +71,7 @@ inputs = {
   vpc_id             = dependency.shared_infra.outputs.vpc_id
   private_subnet_ids = dependency.shared_infra.outputs.private_subnet_ids
   public_subnet_ids  = dependency.shared_infra.outputs.public_subnet_ids
+  db_security_group_id = dependency.shared_infra.outputs.sg_db_id
 
   # Cluster
   # cgroup v2 is default on AL2023 — no additional AMI configuration needed.


### PR DESCRIPTION
This pull request adds support for allowing EKS worker nodes to connect to a PostgreSQL database by configuring a security group rule. It introduces a new variable to specify the database's security group and updates the Terraform and Terragrunt configuration to enable this connectivity.

**Networking and Security Updates:**

* Added a new `aws_security_group_rule` resource in `main.tf` to allow ingress traffic from EKS worker nodes to the PostgreSQL port (5432) on the RDS database security group, conditional on the `db_security_group_id` variable being set.
* Introduced a new `db_security_group_id` variable in `variables.tf` to specify the RDS database security group, with a default value of `null` and marked as nullable.

**Infrastructure Configuration Updates:**

* Updated the Terragrunt configuration in `eks/terragrunt.hcl` to pass the database security group ID (`sg_db_id`) from the shared infrastructure dependency to the EKS module as `db_security_group_id`. [[1]](diffhunk://#diff-94e3763bdefbf282f765fb8c9015929a4dd9dad5adaa6172978d1c5259bb0c25R46) [[2]](diffhunk://#diff-94e3763bdefbf282f765fb8c9015929a4dd9dad5adaa6172978d1c5259bb0c25R74)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure configuration to enable PostgreSQL database connectivity from EKS worker nodes via new security group rules.
  * Added conditional security group rule to allow port 5432 access when database security group is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->